### PR TITLE
[DO NOT MERGE] Add submenu button for creating new patterns

### DIFF
--- a/wp-modules/app/app.php
+++ b/wp-modules/app/app.php
@@ -85,6 +85,14 @@ function patternmanager_adminmenu_page() {
 		'dashicons-text',
 		$position = 2,
 	);
+
+	add_submenu_page(
+		'pattern-manager',
+		'', // No additional page should be created.
+		'Add New',
+		'administrator',
+		'patternmanager-add-new-pattern',
+	);
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\patternmanager_adminmenu_page' );
 

--- a/wp-modules/app/js/src/components/PatternManagerApp/index.tsx
+++ b/wp-modules/app/js/src/components/PatternManagerApp/index.tsx
@@ -3,7 +3,7 @@ import '../../../../css/src/index.scss';
 import wpeLogoDefaultCropped from '../../../../img/WPE-LOGO-S-Default-Cropped.svg';
 
 // WP dependencies
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { Snackbar, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -113,6 +113,44 @@ function PatternManager() {
 	const { currentPatternId, currentView, currentTheme } = usePmContext();
 	const { snackBarValue, setSnackBarValue } = useNoticeContext();
 
+	const createNewPattern = () => {
+		// Get the new pattern title and slug.
+		const { patternTitle, patternSlug } = getNextPatternIds(
+			currentTheme?.data?.included_patterns
+		);
+
+		currentTheme
+			.createPattern( {
+				type: 'pattern',
+				title: patternTitle,
+				name: patternSlug,
+				slug: patternSlug,
+				categories: [],
+				keywords: [],
+				blockTypes: [],
+				postTypes: [],
+				inserter: true,
+				description: '',
+				viewportWidth: '',
+				content: '',
+			} )
+			.then( () => {
+				currentPatternId.set( patternSlug );
+				currentView.set( 'pattern_editor' );
+			} );
+	};
+
+	useEffect( () => {
+		const addPatternSubmenuNode = document.querySelector(
+			'[href="patternmanager-add-new-pattern"]'
+		);
+
+		addPatternSubmenuNode.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+			createNewPattern();
+		} );
+	}, [] );
+
 	return (
 		<>
 			{ snackBarValue ? (
@@ -156,36 +194,7 @@ function PatternManager() {
 						) }
 					</button>
 
-					<button
-						className="nav-button"
-						onClick={ () => {
-							// Get the new pattern title and slug.
-							const { patternTitle, patternSlug } =
-								getNextPatternIds(
-									currentTheme?.data?.included_patterns
-								);
-
-							currentTheme
-								.createPattern( {
-									type: 'pattern',
-									title: patternTitle,
-									name: patternSlug,
-									slug: patternSlug,
-									categories: [],
-									keywords: [],
-									blockTypes: [],
-									postTypes: [],
-									inserter: true,
-									description: '',
-									viewportWidth: '',
-									content: '',
-								} )
-								.then( () => {
-									currentPatternId.set( patternSlug );
-									currentView.set( 'pattern_editor' );
-								} );
-						} }
-					>
+					<button className="nav-button" onClick={ createNewPattern }>
 						{ __( 'Add New Pattern', 'pattern-manager' ) }
 					</button>
 				</div>


### PR DESCRIPTION
This PR simply adds a pattern creation button to the admin submenu:

![Screen Shot 2023-01-17 at 12 15 08 PM](https://user-images.githubusercontent.com/108079556/212979124-9193dce2-0ee0-434d-90bc-76962e546316.png)

The addition of this button feels more like what is available for a traditional custom post type, and it arguably should feel more core-adjacent.

---

### How to test
<!-- Detailed steps to test this PR. -->
1. Checkout the branch
2. Try out the `Add New` button in the admin menu

---

### Notes
<!-- Additional information for reviewers. -->
Hovering on the new submenu button will show an address of the "fake" URL required by `add_submenu_item` in your browser status bar. Clicking on this URL is intercepted by the event listener in this PR, so the URL address being shown page does not actually exist:

![Screen Shot 2023-01-17 at 12 22 03 PM](https://user-images.githubusercontent.com/108079556/212980360-464a220e-fb35-423d-b7c7-203b5d399791.png)