### PR TITLE
Make the core save button work

### DIFF
--- a/wp-modules/pattern-post-type/css/src/index.scss
+++ b/wp-modules/pattern-post-type/css/src/index.scss
@@ -10,8 +10,8 @@
 	display: none !important;
 }
 
-/* Hide the publish/save button in the pattern editor, as the save theme button handles it. */
-.editor-post-publish-panel__toggle {
+/* When the save button is clicked, hide the pre-publish panel that pops open, as we handle saving in PM. */
+.editor-post-publish-panel {
 	display: none !important;
 }
 

--- a/wp-modules/pattern-post-type/js/src/components/PatternManagerMetaControls/index.tsx
+++ b/wp-modules/pattern-post-type/js/src/components/PatternManagerMetaControls/index.tsx
@@ -1,12 +1,14 @@
 import PatternEditorSidebar from '../PatternEditorSidebar';
 import usePostData from '../../hooks/usePostData';
 import useSubscription from '../../hooks/useSubscription';
+import useSaveButtonInterrupter from '../../hooks/useSaveButtonInterrupter';
 import useFilters from '../../hooks/useFilters';
 
 export default function PatternManagerMetaControls() {
 	const { coreLastUpdate, postMeta, currentPostType, postDirty } =
 		usePostData();
 	useSubscription( currentPostType, postDirty );
+	useSaveButtonInterrupter();
 	useFilters( postMeta );
 
 	// Will only render component for post type 'pm_pattern'.

--- a/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
+++ b/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
@@ -1,0 +1,28 @@
+import { useEffect } from '@wordpress/element';
+import { select, subscribe, dispatch } from '@wordpress/data';
+
+export default function useSaveButtonInterrupter() {
+	function handleSave( event ) {
+		event.preventDefault();
+		window.parent.postMessage( 'pattern_manager_save_current_pattern' );
+	}
+
+	useEffect( () => {
+		const saveButtons = document.getElementsByClassName(
+			'editor-post-publish-panel__toggle'
+		);
+
+		for ( let i = 0; i < saveButtons.length; i++ ) {
+			saveButtons[ i ].addEventListener( 'click', handleSave, false );
+		}
+
+		// While the above event listeners handle interrupting save button clicks, this also handles keyboard shortcut saves (like cmd+s).
+		subscribe( () => {
+			if ( select( 'core/editor' ).isSavingPost() ) {
+				window.parent.postMessage(
+					'pattern_manager_save_current_pattern'
+				);
+			}
+		} );
+	}, [] );
+}


### PR DESCRIPTION
This PR un-hides the "Save" button in the pattern editor, and makes it work. 

**What this PR does not do:**
- It does not change any saving logic
- It does not remove the existing top toolbar
