### PR TITLE
In package.json, escape the path so it works for paths with spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
 	"wpps_options": "-n PatternManager -t pattern-manager",
 	"scripts": {
 		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
-		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p $OLDPWD;",
-		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p $OLDPWD;",
-		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p $OLDPWD;",
-		"lint:php": "cd ../../wpps-scripts; sh phpcs.sh $npm_package_wpps_options -p $OLDPWD;",
-		"lint:php:fix": "cd ../../wpps-scripts; sh phpcs.sh $npm_package_wpps_options -p $OLDPWD -f 1;",
-		"lint:js": "cd ../../wpps-scripts; sh lint-js.sh $npm_package_wpps_options -p $OLDPWD",
-		"lint:js:fix": "cd ../../wpps-scripts; sh lint-js.sh $npm_package_wpps_options -p $OLDPWD -f 1;",
-		"lint:css": "cd ../../wpps-scripts; sh lint-css.sh $npm_package_wpps_options -p $OLDPWD;",
-		"lint:css:fix": "cd ../../wpps-scripts; sh lint-css.sh $npm_package_wpps_options -p $OLDPWD -f 1;",
-		"test:js": "cd ../../wpps-scripts; sh test-js.sh $npm_package_wpps_options -p $OLDPWD;",
-		"zip": "cd ../../wpps-scripts; sh zip.sh $npm_package_wpps_options -p $OLDPWD;"
+		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"lint:php": "cd ../../wpps-scripts; sh phpcs.sh $npm_package_wpps_options -p ${OLDPWD};",
+		"lint:php:fix": "cd ../../wpps-scripts; sh phpcs.sh $npm_package_wpps_options -p \"${OLDPWD}\" -f 1;",
+		"lint:js": "cd ../../wpps-scripts; sh lint-js.sh $npm_package_wpps_options -p \"${OLDPWD}\"",
+		"lint:js:fix": "cd ../../wpps-scripts; sh lint-js.sh $npm_package_wpps_options -p \"${OLDPWD}\" -f 1;",
+		"lint:css": "cd ../../wpps-scripts; sh lint-css.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"lint:css:fix": "cd ../../wpps-scripts; sh lint-css.sh $npm_package_wpps_options -p \"${OLDPWD}\" -f 1;",
+		"test:js": "cd ../../wpps-scripts; sh test-js.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"zip": "cd ../../wpps-scripts; sh zip.sh $npm_package_wpps_options -p \"${OLDPWD}\";"
 	}
 }


### PR DESCRIPTION
This PR escapes the path in package.json so that file paths with spaces work.

For example, if you cloned this plugin to `/some/path/with spaces/wp-content/pattern-manager`, prior to this you would get problems if you ran `npm run lint:php`. 

Now it should work fine. 