### PR TITLE
Add quotation marks back to search count text

### DIFF
--- a/wp-modules/app/js/src/components/Patterns/SearchCount.tsx
+++ b/wp-modules/app/js/src/components/Patterns/SearchCount.tsx
@@ -15,8 +15,8 @@ export default function SearchCount( { resultsLength, searchTerm }: Props ) {
 				{ sprintf(
 					/* translators: %1$d: the number of patterns found, %2$s: the search term for patterns */
 					_n(
-						'%1$d pattern found for %2$s',
-						'%1$d patterns found for %2$s',
+						'%1$d pattern found for "%2$s"',
+						'%1$d patterns found for "%2$s"',
 						resultsLength,
 						'pattern-manager'
 					),


### PR DESCRIPTION
This just adds in quotation marks that were unintentionally left out in https://github.com/studiopress/pattern-manager/pull/33. For example in the screenshot below, "baby" is now in quotes:

<img width="344" alt="Screen Shot 2023-01-24 at 2 47 49 PM" src="https://user-images.githubusercontent.com/108079556/214408223-28ea32a7-c86e-4e9f-a624-6ee21804e9ad.png">

No review needed!