### PR TITLE
Add label to search field

### DIFF
--- a/wp-modules/app/js/src/components/Patterns/index.tsx
+++ b/wp-modules/app/js/src/components/Patterns/index.tsx
@@ -62,7 +62,10 @@ export default function Patterns() {
 						<div className="inner-sidebar">
 							<SearchControl
 								className="pattern-search"
-								label={ __( 'Search Patterns', 'pattern-manager' ) }
+								label={ __(
+									'Search Patterns',
+									'pattern-manager'
+								) }
 								value={ searchTerm }
 								onChange={ ( newSearchTerm: string ) => {
 									setSearchTerm( newSearchTerm );


### PR DESCRIPTION
A11y: adds a label to the pattern search field. Fixes error below.

Using the [Wave add](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US) on for Chrome:

<img width="285" alt="Screen Shot 2023-02-02 at 2 49 30 PM" src="https://user-images.githubusercontent.com/1271053/216437400-74816b6d-5397-43ca-ad2b-a98629c6b67a.png">

The component automatically visually hides the label so there are no changes to the CSS.