### PR TITLE
[DO NOT MERGE] Save-pattern experience improvements

### DIFF
--- a/wp-modules/api-data/api-data.php
+++ b/wp-modules/api-data/api-data.php
@@ -124,7 +124,12 @@ function save_pattern( $request ) {
 			),
 			200
 		)
-		: new WP_REST_Response( $is_success, 400 );
+		: new WP_REST_Response(
+			array(
+				'message' => __( 'Something went wrong while saving the pattern.', 'pattern-manager' ),
+			),
+			400
+		);
 }
 
 /**
@@ -143,7 +148,12 @@ function save_patterns( $request ) {
 			),
 			200
 		)
-		: new WP_REST_Response( $is_success, 400 );
+		: new WP_REST_Response(
+			array(
+				'message' => __( 'Something went wrong while saving the patterns.', 'pattern-manager' ),
+			),
+			400
+		);
 }
 
 /**

--- a/wp-modules/pattern-post-type/css/src/index.scss
+++ b/wp-modules/pattern-post-type/css/src/index.scss
@@ -19,11 +19,6 @@ button.components-button.editor-post-save-draft.is-tertiary {
 	display: none;
 }
 
-/* Hide the snackbar on the pattern editor, as the pattern-manager app has its own snackbar. */
-.components-snackbar {
-	display: none !important;
-}
-
 /* Toggle components */
 .patternmanager-post-type-modal-toggle,
 .patternmanager-inserter-toggle {

--- a/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
+++ b/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
@@ -1,6 +1,6 @@
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect, select, subscribe} from '@wordpress/data';
+import { useDispatch, useSelect, select, subscribe } from '@wordpress/data';
 import getHeaders from '../utils/getHeaders';
 import { patternManager } from '../globals';
 import type { Pattern, SelectQuery } from '../types';
@@ -9,9 +9,7 @@ import { __ } from '@wordpress/i18n';
 export default function useSaveButtonInterrupter(
 	setPatternNames: ( patternNames: Array< Pattern[ 'name' ] > ) => void
 ) {
-	const isSavingPost = useSelect( ( select: SelectQuery ) => {
-		return select( 'core/editor' ).isSavingPost();
-	}, [] );
+	const isSavingPost = select( 'core/editor' ).isSavingPost();
 	const editor = useSelect( editorStore, [] );
 	const { editPost, lockPostAutosaving } = useDispatch( 'core/editor' );
 
@@ -36,10 +34,9 @@ export default function useSaveButtonInterrupter(
 		// While the above event listeners handle interrupting save button clicks, this also handles keyboard shortcut saves (like cmd+s).
 		subscribe( () => {
 			if ( select( 'core/editor' ).isSavingPost() ) {
-				handleSave(null);
+				handleSave( null );
 			}
 		} );
-
 	}, [] );
 
 	async function handleSave( event?: Event ) {
@@ -55,10 +52,8 @@ export default function useSaveButtonInterrupter(
 				'editor-post-publish-panel__toggle'
 			)
 		).forEach( ( saveButton ) => {
-			const textContent = saveButton.textContent;
 			saveButton.setAttribute( 'disabled', 'disabled' );
-			saveButton.setAttribute( 'originalText', textContent );
-			saveButton.textContent = __( 'Saving pattern...', 'pattern-manager' );
+			saveButton.textContent = __( 'Saving pattern…', 'pattern-manager' );
 		} );
 
 		// If the pattern name changed, update the URL query param 'name'.
@@ -96,10 +91,10 @@ export default function useSaveButtonInterrupter(
 				)
 			).forEach( ( saveButton ) => {
 				saveButton.removeAttribute( 'disabled' );
-				saveButton.textContent = saveButton.getAttribute( 'originalText' );
+				saveButton.textContent = __( 'Save pattern to theme', 'pattern-manager' );
 				saveButton.removeAttribute( 'originalText' );
 			} );
-		});
+		} );
 	}
 
 	async function updatePatternNames() {

--- a/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
+++ b/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
@@ -87,7 +87,15 @@ export default function useSaveButtonInterrupter(
 			} ),
 		} )
 			.then( async ( response ) => {
-				const data: { message: string } = await response.json();
+				let data: { message: string } = {
+					message: __( 'Something went wrong', 'pattern-manager' ),
+				};
+
+				try {
+					data = await response.json();
+				} catch ( error: any ) {
+					throw error;
+				}
 
 				if ( ! response.ok ) {
 					throw data;
@@ -111,11 +119,15 @@ export default function useSaveButtonInterrupter(
 					isDismissible: true,
 				} );
 			} )
-			.catch( ( data: { message: string } ) => {
-				createNotice( 'error', data.message, {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
+			.catch( ( data: any ) => {
+				createNotice(
+					'error',
+					data.message ? data?.message : JSON.stringify( data ),
+					{
+						type: 'snackbar',
+						isDismissible: true,
+					}
+				);
 			} );
 	}
 

--- a/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
+++ b/wp-modules/pattern-post-type/js/src/hooks/useSaveButtonInterrupter.ts
@@ -87,6 +87,19 @@ export default function useSaveButtonInterrupter(
 			} ),
 		} )
 			.then( async ( response ) => {
+				// Put the save button back the way it was.
+				Object.values(
+					document.getElementsByClassName(
+						'editor-post-publish-panel__toggle'
+					)
+				).forEach( ( saveButton ) => {
+					saveButton.removeAttribute( 'disabled' );
+					saveButton.textContent = __(
+						'Save pattern to theme',
+						'pattern-manager'
+					);
+				} );
+
 				let data: { message: string } = {
 					message: __( 'Something went wrong', 'pattern-manager' ),
 				};
@@ -100,19 +113,6 @@ export default function useSaveButtonInterrupter(
 				if ( ! response.ok ) {
 					throw data;
 				}
-
-				Object.values(
-					document.getElementsByClassName(
-						'editor-post-publish-panel__toggle'
-					)
-				).forEach( ( saveButton ) => {
-					saveButton.removeAttribute( 'disabled' );
-					saveButton.textContent = __(
-						'Save pattern to theme',
-						'pattern-manager'
-					);
-					saveButton.removeAttribute( 'originalText' );
-				} );
 
 				createNotice( 'success', data.message, {
 					type: 'snackbar',


### PR DESCRIPTION
This PR adds a saving indicator, and success or failure handling with the snackbar component in core.

### How to test
1. Save a pattern
2. Notice the button says "Saving Pattern..." and is disabled
3. Once saved, you should see a success snackbar pop-up.
4. If the pattern saving failed you should also see a snackbar with an error message.

## Save button:
<img width="315" alt="Screen Shot 2023-02-08 at 1 21 01 PM" src="https://user-images.githubusercontent.com/7538525/217619776-10c1392a-4537-49a7-9591-00836e82aaa8.png">

## Successful save
<img width="311" alt="Screen Shot 2023-02-08 at 1 21 13 PM" src="https://user-images.githubusercontent.com/7538525/217619778-471e2bfe-03cd-4704-9d06-2eb3ce96a090.png">

## Error after save
<img width="499" alt="Screen Shot 2023-02-08 at 1 21 53 PM" src="https://user-images.githubusercontent.com/7538525/217619779-a0bb391b-ea33-42e9-823f-2211598399da.png">
