### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #team-gen has primary ownership of this repository and is responsible for PR review and approval
 .github/CODEOWNERS @studiopress/team-gen
 
-#jira:[GF] is where issues related to this repository should be ticketed
+#jira: GF is where issues related to this repository should be ticketed


### PR DESCRIPTION
Updates CODEOWNERS file.

- moves to .github directory - every WPE repo I looked at did it this way
- removes .md extension
- removes brackets for Jira - no WPE repos use this, but I figured maybe it will be a requirement in the future. But, brackets are removed from the github team name so I removed them here too.

This should result in a valid notice like the Navigation repo: https://github.com/studiopress/navigation-pro/blob/master/.github/CODEOWNERS

