### PR TITLE
Don't allow saving if there's no pattern title, or if it's a duplicate

### DIFF
--- a/wp-modules/pattern-post-type/js/src/components/SidebarPanels/TitlePanel.tsx
+++ b/wp-modules/pattern-post-type/js/src/components/SidebarPanels/TitlePanel.tsx
@@ -1,4 +1,5 @@
 import { speak } from '@wordpress/a11y';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -24,6 +25,7 @@ export default function TitlePanel( {
 	handleChange,
 	patternNames,
 }: BaseSidebarProps & { patternNames: Array< Pattern[ 'name' ] > } ) {
+	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 
 	return (
@@ -44,6 +46,7 @@ export default function TitlePanel( {
 					} );
 
 					if ( ! newTitle ) {
+						lockPostSaving();
 						const newErrorMessage = __(
 							'Please enter a title.',
 							'pattern-manager'
@@ -53,6 +56,7 @@ export default function TitlePanel( {
 					} else if (
 						isTitleTaken( newTitle, postMeta.slug, patternNames )
 					) {
+						lockPostSaving();
 						const newErrorMessage = __(
 							'Please enter a unique title.',
 							'pattern-manager'
@@ -60,6 +64,7 @@ export default function TitlePanel( {
 						speak( newErrorMessage, 'assertive' );
 						setErrorMessage( newErrorMessage );
 					} else {
+						unlockPostSaving();
 						setErrorMessage( '' );
 					}
 				} }


### PR DESCRIPTION
Jen found there's a PHP error if you save a pattern with no title.

And Michael suggested the client side block saving if there's no title or if it's a duplicate. 

So this PR does that.

Fixes part of https://github.com/studiopress/pattern-manager/issues/57 (Deleting title on the edit screen, then saving results in a php error)

### How to test
<!-- Detailed steps to test this PR. -->
1. Create a new pattern
2. Add some content 
3. Remove the title
4. Expected: The 'Update Pattern' button is disabled: 
<img width="888" alt="Screenshot 2023-02-21 at 12 39 54 PM" src="https://user-images.githubusercontent.com/4063887/220431345-22995071-c6bf-460a-bc8f-8eb512fa7657.png">

5. Add a title
6. Expected: The 'Update Pattern' button isn't disabled: <img width="886" alt="Screenshot 2023-02-21 at 12 40 04 PM" src="https://user-images.githubusercontent.com/4063887/220431454-66606dea-4162-44e2-ad4e-947a6a54d91d.png">
