### PR TITLE
If the theme is a child theme, save patterns to the child theme

### DIFF
--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -190,7 +190,7 @@ function get_theme_patterns_with_editor_links() {
  * @return string
  */
 function get_patterns_directory() {
-	return get_template_directory() . '/patterns/';
+	return get_stylesheet_directory() . '/patterns/';
 }
 
 /**
@@ -320,7 +320,7 @@ function delete_pattern( string $pattern_name ): bool {
 function remove_theme_name_from_template_parts( $pattern_content ) {
 
 	// Find all references to "theme":"anything" and remove them, as we want blocks to work with any theme they are inside of.
-	return preg_replace( '/,"theme":"[A-Za-z-]*"/', ',"theme":"' . basename( get_template_directory() ) . '"', $pattern_content );
+	return preg_replace( '/,"theme":"[A-Za-z-]*"/', ',"theme":"' . basename( get_stylesheet_directory() ) . '"', $pattern_content );
 }
 
 /**
@@ -366,7 +366,7 @@ function tree_shake_theme_images() {
 	// Get the current patterns in the theme (not including templates and templates parts).
 	// Important note: we are not pulling in images from templates and parts because they are html files, and thus cannot reference a local image.
 	// Add the included Patterns for the current theme.
-	$theme_dir         = get_template_directory();
+	$theme_dir         = get_stylesheet_directory();
 	$patterns_in_theme = \PatternManager\PatternDataHandlers\get_theme_patterns();
 
 	$backedup_images_dir = $wp_filesystem->wp_content_dir() . 'temp-images/';
@@ -433,7 +433,7 @@ function move_block_images_to_theme( $pattern_html ) {
 	// Spin up the filesystem api.
 	$wp_filesystem = \PatternManager\GetWpFilesystem\get_wp_filesystem_api();
 
-	$wp_theme_dir = get_template_directory();
+	$wp_theme_dir = get_stylesheet_directory();
 	$assets_dir   = $wp_theme_dir . '/assets/';
 	$images_dir   = $wp_theme_dir . '/patterns/images/';
 

--- a/wp-modules/pattern-post-type/model.php
+++ b/wp-modules/pattern-post-type/model.php
@@ -245,7 +245,7 @@ function add_active_theme_to_heartbeat( $response, $data, $screen_id ) {
 	return get_pattern_post_type() === $screen_id
 		? array_merge(
 			$response,
-			[ 'activeTheme' => basename( get_template_directory() ) ]
+			[ 'activeTheme' => basename( get_stylesheet_directory() ) ]
 		)
 		: $response;
 }

--- a/wp-modules/pattern-post-type/pattern-post-type.php
+++ b/wp-modules/pattern-post-type/pattern-post-type.php
@@ -261,7 +261,7 @@ function enqueue_meta_fields_in_editor() {
 		'pattern_manager_post_meta',
 		'patternManager',
 		[
-			'activeTheme'  => basename( get_template_directory() ),
+			'activeTheme'  => basename( get_stylesheet_directory() ),
 			'apiEndpoints' => array(
 				'getPatternNamesEndpoint' => get_rest_url( false, 'pattern-manager/v1/get-pattern-names/' ),
 			),


### PR DESCRIPTION
## Before
If the theme was a child theme, this saved patterns in its parent theme.

## After
If the theme is a child theme, this saves patterns in the child theme.

---
Fixes part of https://github.com/studiopress/pattern-manager/issues/57 (Make sure child themes work)

## Testing Steps
1. Activate a child theme
2. Create a new pattern 
3. Expected: The pattern is saved to the child theme's `patterns/` directory, not its parent: <img width="1022" alt="Screenshot 2023-02-22 at 12 56 48 PM" src="https://user-images.githubusercontent.com/4063887/220731754-40b02844-12b9-446d-9a87-c910f4d9a9ac.png">
