### PR TITLE
Update label for screen reader

### DIFF
--- a/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
@@ -27,10 +27,7 @@ export default function ViewportWidthPanel( {
 			title={ __( 'Viewport Width', 'pattern-manager' ) }
 		>
 			<RangeControl
-				label={ __(
-					'Preview width in pixels',
-					'pattern-manager'
-				) }
+				label={ __( 'Preview width in pixels', 'pattern-manager' ) }
 				hideLabelFromVision={ true }
 				help={ __(
 					'Adjust preview width for the pattern.',


### PR DESCRIPTION
Shorten the label with context for the next interaction. Reduces the amount of spoken text and makes the next interaction a little bit more clear when the text is read.

For example: (corrected caps in code)
<img width="695" alt="Screen Shot 2023-02-28 at 5 35 29 PM" src="https://user-images.githubusercontent.com/1271053/221997868-2462c284-9924-4897-a35d-4ee7c4edeaa7.png">
