### PR TITLE
Apply Mike's fix for child theme images

### DIFF
--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -372,7 +372,7 @@ function tree_shake_theme_images() {
 	$backedup_images_dir = $wp_filesystem->wp_content_dir() . 'temp-images/';
 	$images_dir          = $theme_dir . '/patterns/images/';
 
-	$wp_theme_url = get_template_directory_uri();
+	$wp_theme_url = get_stylesheet_directory_uri();
 	$images_url   = $wp_theme_url . '/patterns/images/';
 
 	if ( ! $wp_filesystem->exists( $backedup_images_dir ) ) {
@@ -440,7 +440,7 @@ function move_block_images_to_theme( $pattern_html ) {
 	$assets_dir   = $wp_theme_dir . '/assets/';
 	$images_dir   = $wp_theme_dir . '/patterns/images/';
 
-	$wp_theme_url = get_template_directory_uri();
+	$wp_theme_url = get_stylesheet_directory_uri();
 	$images_url   = $wp_theme_url . '/patterns/images/';
 
 	if ( ! $wp_filesystem->exists( $assets_dir ) ) {
@@ -492,7 +492,7 @@ function move_block_images_to_theme( $pattern_html ) {
 		);
 
 		// Replace the URL with the one we just added to the theme.
-		$pattern_html = str_replace( $url_found, "<?php echo esc_url( get_template_directory_uri() ); ?>/patterns/images/$filename", $pattern_html );
+		$pattern_html = str_replace( $url_found, "<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/patterns/images/$filename", $pattern_html );
 	}
 
 	return $pattern_html;


### PR DESCRIPTION
Applies Mike's fix for child theme images. 

Allows saving images to a child theme.

Fixes https://github.com/studiopress/pattern-manager/issues/83
<!-- See #xxx. -->

### How to test
1. Activate a child theme
2. Create a new pattern
3. Add an Image block
4. Click 'Insert from URL'
5. Enter `https://fastly.picsum.photos/id/90/200/200.jpg?hmac=zltjAmHceKvUbRnvGycGPocNMsLFu-jiTwBEcre1_pU`
6. Save the pattern 
7. Reload the browser
8. Expected: The image still appears: 
<img width="582" alt="Screenshot 2023-02-28 at 5 28 02 PM" src="https://user-images.githubusercontent.com/4063887/222006542-4b12adaf-4d58-45ec-a29f-568a63ac8337.png">

