### PR TITLE
Update the viewportWidth helper text

### DIFF
--- a/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
@@ -30,7 +30,7 @@ export default function ViewportWidthPanel( {
 				label={ __( 'Preview width in pixels', 'pattern-manager' ) }
 				hideLabelFromVision={ true }
 				help={ __(
-					'Adjust the width of the pattern preview in the pattern inserter.',
+					'Adjust the pattern preview width in the pattern inserter.',
 					'pattern-manager'
 				) }
 				min={ 640 }


### PR DESCRIPTION
Fixes an omission for correcting helper text in the `viewportWidth` component.
The helper text revision was from feedback in #80 that I simply missed. D'oh!

### How to test
Not needed — this is only updating helper text for the `viewportWidth` panel component.