### PR TITLE
Bump the version to `0.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
 	"name": "pattern-manager",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pattern-manager",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"license": "GPL-2.0-or-later",
 	"repository": {
 		"type": "git",

--- a/pattern-manager.php
+++ b/pattern-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pattern Manager
  * Plugin URI: wpengine.com
  * Description: Create and maintain patterns.
- * Version: 0.1.2
+ * Version: 0.1.3
  * Author: WP Engine
  * Author URI: wpengine.com
  * Text Domain: pattern-manager


### PR DESCRIPTION
Bumps the version to `0.1.3` so we we'll know what version bug reports are from.

Here's the [diff since 0.1.2](https://github.com/studiopress/pattern-manager/compare/0.1.2...f3d341a).

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

TODO: Publish [draft release](https://github.com/studiopress/pattern-manager/releases/tag/untagged-68cb072cfbae0acecafb) when ready
