### PR TITLE
Add a fallback value back to PatternPreview in the grid

### DIFF
--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -51,7 +51,8 @@ export default function PatternGrid( { themePatterns }: Props ) {
 												patternData.name
 											}
 											viewportWidth={
-												patternData.viewportWidth
+												patternData.viewportWidth ||
+												1280
 											}
 										/>
 									</div>


### PR DESCRIPTION
This is a simple change to fix a small regression.

If no `Viewport Width` is present in the pattern header, the preview scaling can look off:

<img width="1042" alt="Screenshot 2023-03-08 at 2 58 40 PM" src="https://user-images.githubusercontent.com/108079556/223857233-28c12e20-ea39-4cb7-bffa-191abfabde42.png">

---

Having the fallback value makes the preview show as expected:

<img width="955" alt="Screenshot 2023-03-08 at 2 58 53 PM" src="https://user-images.githubusercontent.com/108079556/223857361-56fbf49a-b492-4b23-b34e-4485b1debde9.png">

### How to test
Not needed.
