### PR TITLE
Call `wp_opcache_invalidate()` instead of `opcache_invalidate()`

### DIFF
--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -116,7 +116,7 @@ function format_pattern_data( $pattern_data, $file ) {
 		$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', $text_domain );
 	}
 
-	opcache_invalidate( $file );
+	wp_opcache_invalidate( $file );
 
 	// The actual pattern content is the output of the file.
 	ob_start();
@@ -313,8 +313,6 @@ function update_pattern( $pattern ) {
 		$file_contents,
 		FS_CHMOD_FILE
 	);
-
-	// TO DO: Fix issue with needing to "Save twice" on the frontend, because the pattern files are cached on the first save, making images on disk incorrect.
 
 	return $pattern_file_created;
 }


### PR DESCRIPTION
[wp_opcache_invalidate()](https://developer.wordpress.org/reference/functions/wp_opcache_invalidate/) makes sure the function `opcache_invalidate()` exists, and allows short-circuiting it

### How to test
Not needed
