### PR TITLE
Deprioritize the PM menu item

### DIFF
--- a/wp-modules/app/app.php
+++ b/wp-modules/app/app.php
@@ -76,7 +76,7 @@ function patternmanager_adminmenu_page() {
 		'pattern-manager',
 		__NAMESPACE__ . '\pattern_manager_app',
 		'dashicons-text',
-		$position = 2,
+		$position = 59,
 	);
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\patternmanager_adminmenu_page' );


### PR DESCRIPTION
This PR moves the PM menu item to sit just above appearance:

![Screenshot 2023-03-15 at 11 41 23 AM](https://user-images.githubusercontent.com/108079556/225381066-f39791c3-4b87-4151-ac53-39bc3faf00b8.png)

---

### How to test
Not really needed, but you if want to see it on your local:
1. Checkout the branch
2. Take a gander at the menu item position
