### PR TITLE
Escape pattern preview content

### DIFF
--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -193,6 +193,7 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\disable_autosave' );
  * Receive pattern id in the URL and display its content. Useful for pattern previews and thumbnails.
  */
 function display_block_pattern_preview() {
+	// Nonce not required as the user is not taking any action here.
 	if ( ! isset( $_GET['pm_pattern_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return;
 	}


### PR DESCRIPTION
This PR uses `wp_kses_post` to escape content used for pattern preview iFrames. This is just to help protect against malicious scripts that might be embedded in the pattern.

---

Before (`<script>` tags allowed):

<img width="589" alt="Screenshot 2023-03-16 at 10 39 49 AM" src="https://user-images.githubusercontent.com/108079556/225671237-a618eaff-5319-4fb0-9bd8-41a48cfb5caa.png">

---

After (`<script>` tags have been stripped):

<img width="621" alt="Screenshot 2023-03-16 at 10 40 07 AM" src="https://user-images.githubusercontent.com/108079556/225671443-cd6aa328-8d04-4226-834d-6b801fec8b8e.png">

---

### How to test
<!-- Detailed steps to test this PR. -->
1. Checkout the branch
2. Make sure previews load as expected
3. If you are really enterprising, try to add an additional script — it should not execute
