### PR TITLE
[DO NOT MERGE] Use category registration utility file in the patterns dir

### DIFF
--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -174,6 +174,24 @@ function register_pattern_post_type() {
 			'default'      => get_pattern_defaults()['keywords'],
 		)
 	);
+
+	register_post_meta(
+		$post_type_key,
+		'customCategories',
+		array(
+			'show_in_rest' => array(
+				'schema' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+			),
+			'single'       => true,
+			'type'         => 'array',
+			'default'      => [],
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_pattern_post_type' );
 
@@ -263,13 +281,14 @@ function enqueue_meta_fields_in_editor() {
 		'pattern_manager_post_meta',
 		'patternManager',
 		[
-			'activeTheme'  => basename( get_stylesheet_directory() ),
-			'apiEndpoints' => array(
+			'activeTheme'       => basename( get_stylesheet_directory() ),
+			'apiEndpoints'      => array(
 				'getPatternNamesEndpoint' => get_rest_url( false, 'pattern-manager/v1/get-pattern-names/' ),
 			),
-			'apiNonce'     => wp_create_nonce( 'wp_rest' ),
-			'patternNames' => \PatternManager\PatternDataHandlers\get_pattern_names(),
-			'siteUrl'      => get_bloginfo( 'url' ),
+			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
+			'patternNames'      => \PatternManager\PatternDataHandlers\get_pattern_names(),
+			'siteUrl'           => get_bloginfo( 'url' ),
+			'patternCategories' => \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		]
 	);
 

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -288,7 +288,6 @@ function enqueue_meta_fields_in_editor() {
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'patternNames'      => \PatternManager\PatternDataHandlers\get_pattern_names(),
 			'siteUrl'           => get_bloginfo( 'url' ),
-			'patternCategories' => \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		]
 	);
 

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -281,13 +281,13 @@ function enqueue_meta_fields_in_editor() {
 		'pattern_manager_post_meta',
 		'patternManager',
 		[
-			'activeTheme'       => basename( get_stylesheet_directory() ),
-			'apiEndpoints'      => array(
+			'activeTheme'  => basename( get_stylesheet_directory() ),
+			'apiEndpoints' => array(
 				'getPatternNamesEndpoint' => get_rest_url( false, 'pattern-manager/v1/get-pattern-names/' ),
 			),
-			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
-			'patternNames'      => \PatternManager\PatternDataHandlers\get_pattern_names(),
-			'siteUrl'           => get_bloginfo( 'url' ),
+			'apiNonce'     => wp_create_nonce( 'wp_rest' ),
+			'patternNames' => \PatternManager\PatternDataHandlers\get_pattern_names(),
+			'siteUrl'      => get_bloginfo( 'url' ),
 		]
 	);
 

--- a/wp-modules/editor/js/src/components/PatternManagerMetaControls/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternManagerMetaControls/index.tsx
@@ -49,6 +49,7 @@ export default function PatternManagerMetaControls() {
 			<CategoriesPanel
 				categories={ postMeta.categories }
 				categoryOptions={ queriedCategories }
+				customCategories={ postMeta.customCategories }
 				handleChange={ updatePostMeta }
 			/>
 			<KeywordsPanel

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -17,12 +17,20 @@ export default function CategoriesPanel( {
 	handleChange,
 }: BaseSidebarProps< 'categories' | 'customCategories' > &
 	AdditionalSidebarProps< 'categoryOptions' > ) {
-	const combinedSelectedCategories = [
-		...customCategories.filter( ( categoryTitle ) =>
-			categories.includes( convertToSlug( categoryTitle ) )
-		),
-		...categories,
-	];
+	// The list of currently selected categories, formatted for react-select.
+	const selectedCategories: typeof categoryOptions = categories.reduce(
+		( acc, categoryName ) =>
+			! acc.includes( categoryName )
+				? [
+						...acc,
+						categoryOptions.find(
+							( matchedCategory ) =>
+								matchedCategory.value === categoryName
+						),
+				  ]
+				: acc,
+		[]
+	);
 
 	return (
 		<PluginDocumentSettingPanel
@@ -38,20 +46,7 @@ export default function CategoriesPanel( {
 						'Add Pattern Categories',
 						'pattern-manager'
 					) }
-					value={ combinedSelectedCategories.reduce(
-						( acc, categoryName ) =>
-							! acc.includes( categoryName )
-								? [
-										...acc,
-										categoryOptions.find(
-											( matchedCategory ) =>
-												matchedCategory.value ===
-												categoryName
-										),
-								  ]
-								: acc,
-						[]
-					) }
+					value={ selectedCategories }
 					options={ categoryOptions }
 					onChange={ ( categorySelections ) => {
 						const selections = categorySelections.map(
@@ -62,8 +57,9 @@ export default function CategoriesPanel( {
 							( acc, category ) => {
 								const customCategoryFound =
 									selections.includes( category.value ) &&
-									category.pm_meta &&
-									category.pm_meta === 'pm_custom_category';
+									/^pm_custom_category_/.test(
+										category.value
+									);
 
 								return customCategoryFound
 									? [ ...acc, category.label ]
@@ -83,7 +79,9 @@ export default function CategoriesPanel( {
 							{
 								categories: [
 									...categories,
-									convertToSlug( newCategoryTitle ),
+									`pm_custom_category_${ convertToSlug(
+										newCategoryTitle
+									) }`,
 								],
 							}
 						);

--- a/wp-modules/editor/js/src/types.ts
+++ b/wp-modules/editor/js/src/types.ts
@@ -20,7 +20,6 @@ export type SelectQuery = ( dataStore: string ) => {
 	getBlockPatternCategories: () => {
 		name: string;
 		label: string;
-		pm_meta?: string;
 	}[];
 	getBlockTypes: () => { name: string; transforms?: unknown }[];
 	getCurrentPostAttribute: ( attributeName: 'meta' ) => PostMeta;
@@ -61,12 +60,6 @@ export type InitialPatternManager = {
 	apiEndpoints: {
 		getPatternNamesEndpoint: string;
 	};
-	patternCategories: {
-		name: string;
-		label: string;
-		description?: string;
-		pm_meta?: string;
-	}[];
 	patternNames: Array< Pattern[ 'slug' ] >;
 	siteUrl: string;
 };

--- a/wp-modules/editor/js/src/types.ts
+++ b/wp-modules/editor/js/src/types.ts
@@ -3,6 +3,7 @@
 export type PostMeta = {
 	blockTypes: string[];
 	categories: string[];
+	customCategories: string[];
 	description: string;
 	inserter: boolean;
 	keywords: string[];
@@ -16,7 +17,11 @@ export type PatternPostData = PostMeta & {
 };
 
 export type SelectQuery = ( dataStore: string ) => {
-	getBlockPatternCategories: () => { name: string; label: string }[];
+	getBlockPatternCategories: () => {
+		name: string;
+		label: string;
+		pm_meta?: string;
+	}[];
 	getBlockTypes: () => { name: string; transforms?: unknown }[];
 	getCurrentPostAttribute: ( attributeName: 'meta' ) => PostMeta;
 	getEditedPostAttribute: ( postAttribute: string ) => unknown;
@@ -34,6 +39,7 @@ export type SelectQuery = ( dataStore: string ) => {
 export type Pattern = {
 	blockTypes: string[];
 	categories: string[];
+	customCategories: string[];
 	content: string;
 	description: string;
 	inserter: boolean;
@@ -55,6 +61,12 @@ export type InitialPatternManager = {
 	apiEndpoints: {
 		getPatternNamesEndpoint: string;
 	};
+	patternCategories: {
+		name: string;
+		label: string;
+		description?: string;
+		pm_meta?: string;
+	}[];
 	patternNames: Array< Pattern[ 'slug' ] >;
 	siteUrl: string;
 };

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -18,6 +18,7 @@ use function PatternManager\PatternDataHandlers\get_theme_patterns;
 use function PatternManager\PatternDataHandlers\delete_pattern;
 use function PatternManager\PatternDataHandlers\tree_shake_theme_images;
 use function PatternManager\PatternDataHandlers\update_pattern;
+use function PatternManager\PatternDataHandlers\create_category_registration_file;
 
 /**
  * Gets the pattern content and title from the PHP file.
@@ -53,6 +54,9 @@ function save_pattern_to_file( WP_Post $post ) {
 	if ( get_pattern_post_type() !== $post->post_type ) {
 		return;
 	}
+
+	// Add the utility file for custom category registration.
+	create_category_registration_file();
 
 	$pattern = get_pattern_by_name( $post->post_name );
 

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -371,14 +371,23 @@ function construct_pattern_php_file_contents( $pattern_data ) {
  * Viewport Width: ' . $pattern['viewportWidth'] . '
  * Block Types: ' . implode( ', ', $pattern['blockTypes'] ) . '
  * Post Types: ' . implode( ', ', $pattern['postTypes'] ) . '
- * Inserter: ' . ( $pattern['inserter'] ? 'true' : 'false' ) . '
- * Custom Categories: ' . implode( ', ', $pattern['customCategories'] ) . '
+ * Inserter: ' . ( $pattern['inserter'] ? 'true' : 'false' ) . maybe_add_custom_category_header( $pattern['customCategories'] ) . '
  */
 ' . $custom_category_registrations . '
 ?>
 ' . trim( $pattern['content'] ) . '
 ';
 	return $file_contents;
+}
+
+function maybe_add_custom_category_header( $custom_categories ) {
+	$custom_category_header = '';
+
+	if ( ! empty( $custom_categories ) ) {
+		$custom_category_header = "\n * Custom Categories: " . implode( ', ', $custom_categories );
+	}
+
+	return $custom_category_header;
 }
 
 /**

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -380,6 +380,12 @@ function construct_pattern_php_file_contents( $pattern_data ) {
 	return $file_contents;
 }
 
+/**
+ * Returns a string that conditionally contains the custom category header.
+ *
+ * @param array $custom_categories The custom category titles/labels.
+ * @return string
+ */
 function maybe_add_custom_category_header( $custom_categories ) {
 	$custom_category_header = '';
 

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -486,7 +486,7 @@ function register_custom_categories( $custom_category_labels ) {
 			$category_name = strtolower( str_replace( \' \', \'-\', $category_label ) );
 
 			register_block_pattern_category(
-				$category_name,
+				"pm_custom_category_$category_name",
 				array(
 					\'label\'   => $category_label,
 					\'pm_meta\' => \'pm_custom_category\',


### PR DESCRIPTION
This is a modified approach built off #123. Instead of directly inserting the pattern registration calls in pattern files, this PR uses a utility file.

---

With this PR, when adding custom categories, the added code in the pattern file would look something like this:

<img width="770" alt="Screenshot 2023-03-23 at 10 33 59 PM" src="https://user-images.githubusercontent.com/108079556/227418264-cb64dfad-6a95-4a6b-86f5-f54cd0cff94d.png">

---

Inserting registration calls directly in the pattern file (a la #123) would look something like this instead:

<img width="752" alt="Screenshot 2023-03-23 at 3 31 39 PM" src="https://user-images.githubusercontent.com/108079556/227418440-d6147370-8382-4371-8825-8ccd8b806f71.png">

---

No testing needed yet. This is intended as experimentation to see if something like this is worth pursuing.
