### PR TITLE
[DO NOT MERGE] Show registration code block for new categories

### DIFF
--- a/wp-modules/editor/css/src/index.scss
+++ b/wp-modules/editor/css/src/index.scss
@@ -95,3 +95,38 @@ button.components-button.editor-post-switch-to-draft.is-tertiary {
 		box-shadow: 0 0 0 1px #2684ff;
 	}
 }
+
+.custom-category-warning-card {
+	margin-top: 15px;
+	border-radius: 3px;
+
+	&-body {
+		background: #ffffdf;
+	}
+}
+
+.custom-category-registration-card {
+	margin-top: 15px;
+	border-radius: 3px;
+
+	&-header {
+		background: #e6e5e5;
+	}
+
+	&-body {
+		background: #f3f3f3;
+
+		&-inner {
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			overflow: hidden;
+			padding-top: 15px;
+			padding-bottom: 15px;
+
+			&-code {
+				display: relative;
+				margin-left: 20px;
+			}
+		}
+	}
+}

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -174,6 +174,24 @@ function register_pattern_post_type() {
 			'default'      => get_pattern_defaults()['keywords'],
 		)
 	);
+
+	register_post_meta(
+		$post_type_key,
+		'customCategories',
+		array(
+			'show_in_rest' => array(
+				'schema' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+			),
+			'single'       => true,
+			'type'         => 'array',
+			'default'      => get_pattern_defaults()['customCategories'],
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_pattern_post_type' );
 

--- a/wp-modules/editor/js/src/components/PatternManagerMetaControls/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternManagerMetaControls/index.tsx
@@ -49,6 +49,7 @@ export default function PatternManagerMetaControls() {
 			<CategoriesPanel
 				categories={ postMeta.categories }
 				categoryOptions={ queriedCategories }
+				customCategories={ postMeta.customCategories }
 				handleChange={ updatePostMeta }
 			/>
 			<KeywordsPanel

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -23,7 +23,10 @@ export default function CategoriesPanel( {
 			! acc.includes( categoryName )
 				? [
 						...acc,
-						[ ...categoryOptions, ...getMissingPmCategories() ].find(
+						[
+							...categoryOptions,
+							...getMissingPmCategories(),
+						].find(
 							( matchedCategory ) =>
 								matchedCategory.value === categoryName
 						),
@@ -47,7 +50,7 @@ export default function CategoriesPanel( {
 			label: missingLabel,
 			value: convertToSlug( missingLabel ),
 		} ) );
-	};
+	}
 
 	return (
 		<PluginDocumentSettingPanel
@@ -111,7 +114,7 @@ export default function CategoriesPanel( {
 					{ getMissingPmCategories().length
 						? getMissingPmCategories().map( ( missingCategory ) => {
 								return (
-									<div>
+									<div key={ missingCategory.value }>
 										Missing: { missingCategory.label }
 									</div>
 								);

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { Spinner } from '@wordpress/components';
 import Creatable from 'react-select/creatable';
+import CategoryRegistration from './Tertiary/CategoryRegistration';
 import convertToSlug from '../../utils/convertToSlug';
 
 import type { BaseSidebarProps, AdditionalSidebarProps } from './types';
@@ -111,15 +112,11 @@ export default function CategoriesPanel( {
 						} }
 					/>
 
-					{ getMissingPmCategories().length
-						? getMissingPmCategories().map( ( missingCategory ) => {
-								return (
-									<div key={ missingCategory.value }>
-										Missing: { missingCategory.label }
-									</div>
-								);
-						  } )
-						: null }
+					{ getMissingPmCategories().length ? (
+						<CategoryRegistration
+							categoryOptions={ getMissingPmCategories() }
+						/>
+					) : null }
 				</>
 			) : (
 				<Spinner />

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -63,7 +63,7 @@ export default function CategoriesPanel( {
 					<Creatable
 						isMulti
 						isClearable
-						closeMenuOnSelect={ false }
+						closeMenuOnSelect
 						aria-label={ __(
 							'Add Pattern Categories',
 							'pattern-manager'

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { Spinner } from '@wordpress/components';
-import Select from 'react-select';
+import Creatable from 'react-select/creatable';
+import convertToSlug from '../../utils/convertToSlug';
 
 import type { BaseSidebarProps, AdditionalSidebarProps } from './types';
 
@@ -12,46 +13,111 @@ import type { BaseSidebarProps, AdditionalSidebarProps } from './types';
 export default function CategoriesPanel( {
 	categories,
 	categoryOptions,
+	customCategories,
 	handleChange,
-}: BaseSidebarProps< 'categories' > &
+}: BaseSidebarProps< 'categories' | 'customCategories' > &
 	AdditionalSidebarProps< 'categoryOptions' > ) {
+	// The list of currently selected categories, formatted for react-select.
+	const selectedCategories: typeof categoryOptions = categories.reduce(
+		( acc, categoryName ) =>
+			! acc.includes( categoryName )
+				? [
+						...acc,
+						[ ...categoryOptions, ...getMissingPmCategories() ].find(
+							( matchedCategory ) =>
+								matchedCategory.value === categoryName
+						),
+				  ]
+				: acc,
+		[]
+	);
+
+	function getMissingPmCategories() {
+		const categoryLabels = categoryOptions?.map(
+			( category ) => category.label
+		);
+
+		const missingCategoryLabels = customCategories.filter(
+			( customCategoryLabel ) =>
+				categoryLabels.length &&
+				! categoryLabels.includes( customCategoryLabel )
+		);
+
+		return missingCategoryLabels.map( ( missingLabel ) => ( {
+			label: missingLabel,
+			value: convertToSlug( missingLabel ),
+		} ) );
+	};
+
 	return (
 		<PluginDocumentSettingPanel
 			name="patternmanager-pattern-editor-pattern-categories"
 			title={ __( 'Pattern Categories', 'pattern-manager' ) }
 		>
 			{ categoryOptions ? (
-				<Select
-					isMulti
-					isClearable
-					closeMenuOnSelect={ false }
-					aria-label={ __(
-						'Add Pattern Categories',
-						'pattern-manager'
-					) }
-					value={ categories?.map( ( category ) =>
-						categoryOptions.find(
-							( matchedCategory ) =>
-								matchedCategory.value === category
-						)
-					) }
-					options={ categoryOptions }
-					onChange={ ( categorySelections ) => {
-						handleChange(
-							'categories',
-							categorySelections.map(
+				<>
+					<Creatable
+						isMulti
+						isClearable
+						closeMenuOnSelect={ false }
+						aria-label={ __(
+							'Add Pattern Categories',
+							'pattern-manager'
+						) }
+						value={ selectedCategories }
+						options={ categoryOptions }
+						onChange={ ( categorySelections ) => {
+							const selections = categorySelections.map(
 								( category ) => category.value
-							)
-						);
-					} }
-					menuPlacement="auto"
-					styles={ {
-						menu: ( base ) => ( {
-							...base,
-							zIndex: 100,
-						} ),
-					} }
-				/>
+							);
+
+							const customCategorySelections =
+								categorySelections.reduce(
+									( acc, { label } ) =>
+										customCategories.includes( label )
+											? [ ...acc, label ]
+											: acc,
+									[]
+								);
+
+							handleChange( 'categories', selections, {
+								customCategories: customCategorySelections,
+							} );
+						} }
+						onCreateOption={ ( newCategoryTitle ) => {
+							handleChange(
+								'categories',
+								[
+									...categories,
+									convertToSlug( newCategoryTitle ),
+								],
+								{
+									customCategories: [
+										...customCategories,
+										newCategoryTitle,
+									],
+								}
+							);
+						} }
+						menuPlacement="auto"
+						styles={ {
+							menu: ( base ) => ( {
+								...base,
+								zIndex: 100,
+							} ),
+						} }
+					/>
+
+					{ getMissingPmCategories().length
+						? getMissingPmCategories().map( ( missingCategory ) => {
+								return (
+									<div>
+										Missing: { missingCategory.label }
+									</div>
+								);
+						  } )
+						: null }
+				</>
 			) : (
 				<Spinner />
 			) }

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { Spinner } from '@wordpress/components';
 import Creatable from 'react-select/creatable';
-import CategoryRegistration from './Tertiary/CategoryRegistration';
+import CategoryRegistration from './CategoryRegistration';
 import convertToSlug from '../../utils/convertToSlug';
 
 import type { BaseSidebarProps, AdditionalSidebarProps } from './types';

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/RegistrationTextPreview.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/RegistrationTextPreview.tsx
@@ -1,0 +1,21 @@
+import { AdditionalSidebarProps } from '../types';
+
+export default function RegistrationTextPreview( {
+	categoryOptions,
+}: AdditionalSidebarProps< 'categoryOptions' > ) {
+	return (
+		<>
+			{ `add_action( 'init', function () {` } <br />
+			{ categoryOptions.map( ( category ) => (
+				<span
+					key={ category.value }
+					style={ { display: 'relative', marginLeft: '20px' } }
+				>
+					{ `register_block_pattern_category( '${ category.value }', array( 'label' => '${ category.label }' ) );` }
+					<br />
+				</span>
+			) ) }
+			{ `} );` }
+		</>
+	);
+}

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/RegistrationTextPreview.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/RegistrationTextPreview.tsx
@@ -9,7 +9,7 @@ export default function RegistrationTextPreview( {
 			{ categoryOptions.map( ( category ) => (
 				<span
 					key={ category.value }
-					style={ { display: 'relative', marginLeft: '20px' } }
+					className="custom-category-registration-card-body-inner-code"
 				>
 					{ `register_block_pattern_category( '${ category.value }', array( 'label' => '${ category.label }' ) );` }
 					<br />

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/index.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/index.tsx
@@ -6,14 +6,16 @@ import {
 	CardHeader,
 	ClipboardButton,
 } from '@wordpress/components';
-
+import RegistrationTextPreview from './RegistrationTextPreview';
 import getCategoryRegistrationText from '../../../utils/getCategoryRegistrationText';
+
 import { AdditionalSidebarProps } from '../types';
 
 export default function CategoryRegistration( {
 	categoryOptions,
 }: AdditionalSidebarProps< 'categoryOptions' > ) {
 	const [ hasCopied, setHasCopied ] = useState( false );
+	const textToCopy = getCategoryRegistrationText( categoryOptions );
 
 	return (
 		<>
@@ -31,7 +33,7 @@ export default function CategoryRegistration( {
 					<span>Add to functions.php</span>
 					<ClipboardButton
 						isTertiary
-						text={ getCategoryRegistrationText( categoryOptions ) }
+						text={ textToCopy }
 						onCopy={ () => setHasCopied( true ) }
 						onFinishCopy={ () => setHasCopied( false ) }
 					>
@@ -53,30 +55,13 @@ export default function CategoryRegistration( {
 						} }
 					>
 						{
-							<FormattedTextPreview
+							<RegistrationTextPreview
 								categoryOptions={ categoryOptions }
 							/>
 						}
 					</div>
 				</CardBody>
 			</Card>
-		</>
-	);
-}
-
-function FormattedTextPreview( {
-	categoryOptions,
-}: AdditionalSidebarProps< 'categoryOptions' > ) {
-	return (
-		<>
-			{ `add_action( 'init', function () {` } <br />
-			{ categoryOptions.map( ( category ) => (
-				<>
-					{ `register_block_pattern_category( '${ category.value }', array( 'label' => '${ category.label }' ) );` }
-					<br />
-				</>
-			) ) }
-			{ `} );` }
 		</>
 	);
 }

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/index.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoryRegistration/index.tsx
@@ -19,17 +19,14 @@ export default function CategoryRegistration( {
 
 	return (
 		<>
-			<Card
-				status="warning"
-				style={ { marginTop: '15px', borderRadius: '3px' } }
-			>
-				<CardBody style={ { background: '#ffffdf' } }>
+			<Card status="warning" className="custom-category-warning-card">
+				<CardBody className="custom-category-warning-card-body">
 					Heads up, you need to register these categories in your
 					theme. Add them to your theme with the following code.
 				</CardBody>
 			</Card>
-			<Card style={ { marginTop: '15px', borderRadius: '3px' } }>
-				<CardHeader style={ { background: '#e6e5e5' } }>
+			<Card className="custom-category-registration-card">
+				<CardHeader className="custom-category-registration-card-header">
 					<span>Add to functions.php</span>
 					<ClipboardButton
 						isTertiary
@@ -44,16 +41,8 @@ export default function CategoryRegistration( {
 						) }
 					</ClipboardButton>
 				</CardHeader>
-				<CardBody style={ { background: '#f3f3f3' } }>
-					<div
-						style={ {
-							textOverflow: 'ellipsis',
-							whiteSpace: 'nowrap',
-							overflow: 'hidden',
-							paddingTop: '15px',
-							paddingBottom: '15px',
-						} }
-					>
+				<CardBody className="custom-category-registration-card-body">
+					<div className="custom-category-registration-card-body-inner">
 						{
 							<RegistrationTextPreview
 								categoryOptions={ categoryOptions }

--- a/wp-modules/editor/js/src/components/SidebarPanels/PostTypesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/PostTypesPanel.tsx
@@ -37,7 +37,7 @@ export default function PostTypesPanel( {
 				<Select
 					isMulti
 					isClearable
-					closeMenuOnSelect={ false }
+					closeMenuOnSelect
 					aria-label={ __( 'Select post types', 'pattern-manager' ) }
 					value={ postTypes?.map( ( postType ) => {
 						return {

--- a/wp-modules/editor/js/src/components/SidebarPanels/Tertiary/CategoryRegistration.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/Tertiary/CategoryRegistration.tsx
@@ -7,27 +7,13 @@ import {
 	ClipboardButton,
 } from '@wordpress/components';
 
+import getCategoryRegistrationText from '../../../utils/getCategoryRegistrationText';
 import { AdditionalSidebarProps } from '../types';
 
 export default function CategoryRegistration( {
 	categoryOptions,
 }: AdditionalSidebarProps< 'categoryOptions' > ) {
 	const [ hasCopied, setHasCopied ] = useState( false );
-
-	/** This text formatting madness is all super ugly. Don't judge it too much for this proof-of-concept! */
-	const formattedCategoriesToCopy = categoryOptions.reduce(
-		( acc, category ) =>
-			`register_block_pattern_category( '${
-				category.value
-			}', array( 'label' => '${ category.label }' ) );${
-				acc.length ? '\n\t' + acc : ''
-			}`,
-		''
-	);
-
-	const textToCopy = `add_action( 'init', function () {
-	${ formattedCategoriesToCopy }
-} );`;
 
 	return (
 		<>
@@ -45,7 +31,7 @@ export default function CategoryRegistration( {
 					<span>Add to functions.php</span>
 					<ClipboardButton
 						isTertiary
-						text={ textToCopy }
+						text={ getCategoryRegistrationText( categoryOptions ) }
 						onCopy={ () => setHasCopied( true ) }
 						onFinishCopy={ () => setHasCopied( false ) }
 					>

--- a/wp-modules/editor/js/src/components/SidebarPanels/Tertiary/CategoryRegistration.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/Tertiary/CategoryRegistration.tsx
@@ -1,0 +1,96 @@
+import { useState } from '@wordpress/element';
+import { Icon, copy, check } from '@wordpress/icons';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	ClipboardButton,
+} from '@wordpress/components';
+
+import { AdditionalSidebarProps } from '../types';
+
+export default function CategoryRegistration( {
+	categoryOptions,
+}: AdditionalSidebarProps< 'categoryOptions' > ) {
+	const [ hasCopied, setHasCopied ] = useState( false );
+
+	/** This text formatting madness is all super ugly. Don't judge it too much for this proof-of-concept! */
+	const formattedCategoriesToCopy = categoryOptions.reduce(
+		( acc, category ) =>
+			`register_block_pattern_category( '${
+				category.value
+			}', array( 'label' => '${ category.label }' ) );${
+				acc.length ? '\n\t' + acc : ''
+			}`,
+		''
+	);
+
+	const textToCopy = `add_action( 'init', function () {
+	${ formattedCategoriesToCopy }
+} );`;
+
+	return (
+		<>
+			<Card
+				status="warning"
+				style={ { marginTop: '15px', borderRadius: '3px' } }
+			>
+				<CardBody style={ { background: '#ffffdf' } }>
+					Heads up, you need to register these categories in your
+					theme. Add them to your theme with the following code.
+				</CardBody>
+			</Card>
+			<Card style={ { marginTop: '15px', borderRadius: '3px' } }>
+				<CardHeader style={ { background: '#e6e5e5' } }>
+					<span>Add to functions.php</span>
+					<ClipboardButton
+						isTertiary
+						text={ textToCopy }
+						onCopy={ () => setHasCopied( true ) }
+						onFinishCopy={ () => setHasCopied( false ) }
+					>
+						{ hasCopied ? (
+							<Icon icon={ check } size={ 24 } />
+						) : (
+							<Icon icon={ copy } size={ 24 } />
+						) }
+					</ClipboardButton>
+				</CardHeader>
+				<CardBody style={ { background: '#f3f3f3' } }>
+					<div
+						style={ {
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+							overflow: 'hidden',
+							paddingTop: '15px',
+							paddingBottom: '15px',
+						} }
+					>
+						{
+							<FormattedTextPreview
+								categoryOptions={ categoryOptions }
+							/>
+						}
+					</div>
+				</CardBody>
+			</Card>
+		</>
+	);
+}
+
+function FormattedTextPreview( {
+	categoryOptions,
+}: AdditionalSidebarProps< 'categoryOptions' > ) {
+	return (
+		<>
+			{ `add_action( 'init', function () {` } <br />
+			{ categoryOptions.map( ( category ) => (
+				<>
+					{ `register_block_pattern_category( '${ category.value }', array( 'label' => '${ category.label }' ) );` }
+					<br />
+				</>
+			) ) }
+			{ `} );` }
+		</>
+	);
+}

--- a/wp-modules/editor/js/src/components/SidebarPanels/TransformsPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/TransformsPanel.tsx
@@ -35,7 +35,7 @@ export default function TransformsPanel( {
 				<Select
 					isMulti
 					isClearable
-					closeMenuOnSelect={ false }
+					closeMenuOnSelect
 					aria-label={ __( 'Select block types', 'pattern-manager' ) }
 					value={ blockTypes?.map( ( blockType ) => {
 						// Hide block type related to the post type modal.

--- a/wp-modules/editor/js/src/types.ts
+++ b/wp-modules/editor/js/src/types.ts
@@ -3,6 +3,7 @@
 export type PostMeta = {
 	blockTypes: string[];
 	categories: string[];
+	customCategories: string[];
 	description: string;
 	inserter: boolean;
 	keywords: string[];
@@ -34,6 +35,7 @@ export type SelectQuery = ( dataStore: string ) => {
 export type Pattern = {
 	blockTypes: string[];
 	categories: string[];
+	customCategories: string[];
 	content: string;
 	description: string;
 	inserter: boolean;

--- a/wp-modules/editor/js/src/utils/getCategoryRegistrationText.ts
+++ b/wp-modules/editor/js/src/utils/getCategoryRegistrationText.ts
@@ -1,0 +1,22 @@
+export default function getCategoryRegistrationText(
+	categoryOptions: {
+		label: string;
+		value: string;
+	}[]
+) {
+	const formattedCategoriesToCopy = categoryOptions.reduce(
+		( acc, category ) =>
+			`register_block_pattern_category( '${
+				category.value
+			}', array( 'label' => '${ category.label }' ) );${
+				acc.length ? '\n\t' + acc : ''
+			}`,
+		''
+	);
+
+	const textToCopy = `add_action( 'init', function () {
+	${ formattedCategoriesToCopy }
+} );`;
+
+	return textToCopy;
+}

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -69,7 +69,7 @@ function format_pattern_data( $pattern_data, $file ) {
 	}
 
 	// For properties of type array, parse data as comma-separated.
-	foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes' ) as $property ) {
+	foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes', 'customCategories' ) as $property ) {
 		if ( ! empty( $pattern_data[ $property ] ) ) {
 			$pattern_data[ $property ] = array_map(
 				// Trim whitespace at start and end of each element.
@@ -213,15 +213,16 @@ function get_pattern_file_paths() {
  */
 function get_pattern_by_path( $path ) {
 	$default_headers = array(
-		'title'         => 'Title',
-		'slug'          => 'Slug',
-		'description'   => 'Description',
-		'viewportWidth' => 'Viewport Width',
-		'categories'    => 'Categories',
-		'keywords'      => 'Keywords',
-		'blockTypes'    => 'Block Types',
-		'postTypes'     => 'Post Types',
-		'inserter'      => 'Inserter',
+		'title'            => 'Title',
+		'slug'             => 'Slug',
+		'description'      => 'Description',
+		'viewportWidth'    => 'Viewport Width',
+		'categories'       => 'Categories',
+		'keywords'         => 'Keywords',
+		'blockTypes'       => 'Block Types',
+		'postTypes'        => 'Post Types',
+		'inserter'         => 'Inserter',
+		'customCategories' => 'Custom Categories',
 	);
 
 	$pattern_data = format_pattern_data( get_file_data( $path, $default_headers ), $path );
@@ -239,16 +240,17 @@ function get_pattern_by_path( $path ) {
  */
 function get_pattern_defaults() {
 	return [
-		'name'          => '',
-		'title'         => '',
-		'description'   => '',
-		'content'       => '',
-		'viewportWidth' => 1280,
-		'categories'    => [],
-		'keywords'      => [],
-		'blockTypes'    => [],
-		'postTypes'     => [],
-		'inserter'      => true,
+		'name'             => '',
+		'title'            => '',
+		'description'      => '',
+		'content'          => '',
+		'viewportWidth'    => 1280,
+		'categories'       => [],
+		'keywords'         => [],
+		'blockTypes'       => [],
+		'postTypes'        => [],
+		'inserter'         => true,
+		'customCategories' => [],
 	];
 }
 
@@ -367,13 +369,29 @@ function construct_pattern_php_file_contents( $pattern_data ) {
  * Viewport Width: ' . $pattern['viewportWidth'] . '
  * Block Types: ' . implode( ', ', $pattern['blockTypes'] ) . '
  * Post Types: ' . implode( ', ', $pattern['postTypes'] ) . '
- * Inserter: ' . ( $pattern['inserter'] ? 'true' : 'false' ) . '
+ * Inserter: ' . ( $pattern['inserter'] ? 'true' : 'false' ) . maybe_add_custom_category_header( $pattern['customCategories'] ) . '
  */
 
 ?>
 ' . trim( $pattern['content'] ) . '
 ';
 	return $file_contents;
+}
+
+/**
+ * Returns a string that conditionally contains the custom category header.
+ *
+ * @param array $custom_categories The custom category titles/labels.
+ * @return string
+ */
+function maybe_add_custom_category_header( $custom_categories ) {
+	$custom_category_header = '';
+
+	if ( ! empty( $custom_categories ) ) {
+		$custom_category_header = "\n * Custom Categories: " . implode( ', ', $custom_categories );
+	}
+
+	return $custom_category_header;
 }
 
 /**

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -371,7 +371,6 @@ function construct_pattern_php_file_contents( $pattern_data ) {
  * Post Types: ' . implode( ', ', $pattern['postTypes'] ) . '
  * Inserter: ' . ( $pattern['inserter'] ? 'true' : 'false' ) . maybe_add_custom_category_header( $pattern['customCategories'] ) . '
  */
-
 ?>
 ' . trim( $pattern['content'] ) . '
 ';


### PR DESCRIPTION
The spaghetti JS in this thing is ugly — do not review it yet, please 😅

---

For this rough POC, a notice (with copy button) is shown when new categories are added:

<img width="282" alt="Screenshot 2023-03-28 at 1 45 32 PM" src="https://user-images.githubusercontent.com/108079556/228337499-de3d014c-7dc7-4c70-9670-5d113efec0a4.png">

---

### To-do

- [ ] Move `selectedcategories` reducer out of `CategoriesPanel`
- [ ] Move `getMissingPmCategories()` out of `CategoriesPanel`