### PR TITLE
Make PHPUnit tests pass locally

### DIFF
--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -24,6 +24,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 		parent::setUp();
 		add_filter( 'request_filesystem_credentials', '__return_true' );
 		add_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );
+		add_filter( 'stylesheet_directory_uri', [ $this, 'get_stylesheet_directory_uri' ] );
 	}
 
 	/**
@@ -32,6 +33,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	public function tearDown() {
 		remove_filter( 'request_filesystem_credentials', '__return_true' );
 		remove_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );
+		remove_filter( 'stylesheet_directory_uri', [ $this, 'get_stylesheet_directory_uri' ] );
 		parent::tearDown();
 	}
 
@@ -40,6 +42,13 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	 */
 	public function get_fixtures_directory() {
 		return __DIR__ . '/fixtures';
+	}
+
+	/**
+	 * Gets the stylesheet directory URI.
+	 */
+	public function get_stylesheet_directory_uri() {
+		return 'https://example.com/wp-content/themes/foo';
 	}
 
 	/**


### PR DESCRIPTION
Before, `npm run test:phpunit` failed locally with:

```sh
Time: 8.71 seconds, Memory: 44.50 MB

There was 1 failure:

1) PatternManager\PatternDataHandlers\PatternDataHandlersTest::test_tree_shake_theme_images
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 (
-    0 => '/var/www/html/wp-content/plugins/pattern-manager/wp-modules/pattern-data-handlers/tests/fixtures/patterns/images/used.jpg'
-)
+Array &0 ()

/var/www/html/wp-content/plugins/pattern-manager/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php:198
```

This is because [preg_match() failed](https://github.com/studiopress/pattern-manager/blob/6c708948cb7d012d6b814a1befc648bfe80c8b6c/wp-modules/pattern-data-handlers/pattern-data-handlers.php#L414) on the [test pattern](https://github.com/studiopress/pattern-manager/blob/6c708948cb7d012d6b814a1befc648bfe80c8b6c/wp-modules/pattern-data-handlers/tests/fixtures/patterns/with-image.php#L16):

```php
<!-- wp:image -->
<figure class="wp-block-image size-large"><img src="/wordpress-phpunit/includes/../data/themedir1/default/patterns/images/used.jpg" alt="Cup of tea"/></figure>
<!-- /wp:image -->
```

In that pattern, [get_stylesheet_directory_uri()](https://github.com/studiopress/pattern-manager/blob/6c708948cb7d012d6b814a1befc648bfe80c8b6c/wp-modules/pattern-data-handlers/tests/fixtures/patterns/with-image.php#L16) didn't have `http`:

```php
/wordpress-phpunit/includes/../data/themedir1/default/
```
…so  [preg_match() failed](https://github.com/studiopress/pattern-manager/blob/6c708948cb7d012d6b814a1befc648bfe80c8b6c/wp-modules/pattern-data-handlers/pattern-data-handlers.php#L414).

This PR filters `get_theme_directory_uri()` so it starts with `https://`

### How to test
Not needed. But if you want to:

1. `npm run test:phpunit`
2. Expected: it passes

