### PR TITLE
Make the `core/query` block type available for block transforms

### DIFF
--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -87,6 +87,11 @@ export default function usePatternData( postMeta: PostMeta ) {
 					} ),
 				} ) ),
 			{
+				label: 'core/query',
+				value: 'core/query',
+				transforms: {},
+			},
+			{
 				label: 'core/template-part/header',
 				value: 'core/template-part/header',
 				transforms: {},


### PR DESCRIPTION
Fixes #54.

---

This PR adds the `core/query` block type as a `Transforms (Block Types)` option in the editor sidebar:

![Screenshot 2023-03-31 at 1 36 57 PM](https://user-images.githubusercontent.com/108079556/229203531-ec3e0730-20a3-4c71-8442-dd7557e959fb.png)

---

Other query-related options are currently ignored. All available options are shown below:

![Screenshot 2023-03-31 at 1 32 11 PM](https://user-images.githubusercontent.com/108079556/229203796-0df3ded5-565b-46ce-97a6-63d01f53f03f.png)
