### PR TITLE
Remove pattern registration firing on `current_screen`

### DIFF
--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -281,34 +281,6 @@ function enqueue_meta_fields_in_editor() {
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_meta_fields_in_editor' );
 
 /**
- * If we are on the pattern-manager app page, register the patterns with WP.
- *
- * @return void
- */
-function register_block_patterns() {
-	$current_screen = get_current_screen();
-
-	if ( get_pattern_post_type() !== $current_screen->post_type ) {
-		return;
-	}
-
-	$patterns = \PatternManager\PatternDataHandlers\get_theme_patterns();
-
-	foreach ( $patterns as $pattern ) {
-		if ( isset( $pattern['categories'] ) ) {
-			foreach ( $pattern['categories'] as $category ) {
-				register_block_pattern_category( $category, array( 'label' => ucwords( str_replace( '-', ' ', $category ) ) ) );
-			}
-		}
-		register_block_pattern(
-			$pattern['name'],
-			$pattern,
-		);
-	}
-}
-add_action( 'current_screen', __NAMESPACE__ . '\register_block_patterns', 9 );
-
-/**
  * Enables the Core Comments block to render by adding a 'postId'.
  *
  * TODO: Remove if fixed in Core.


### PR DESCRIPTION
In the editor, we are currently registering patterns and pattern categories by firing from the `current_screen` hook.

This should not be needed since WP 6.1 is required as the minimum version for usage of Pattern Manager. Patterns are registered from files in the `patterns` directory [since WP 6.0](https://make.wordpress.org/core/2022/05/02/new-features-for-working-with-patterns-and-themes-in-wordpress-6-0/), ultimately firing from `init`.

This means that, practically, all patterns and pattern categories are being registered multiple times.

Additionally, firing category registration from `current_screen` [is deprecated](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-block-pattern-categories-registry.php#L69-L77) and seems to cause odd behavior. Firing from `current_screen` can cause the pattern files to be called again from other hooks (such as `the_post`).

---

Removing this call will also help if we decide to register custom categories from pattern files (such as in #123). It would ensure that new categories are only registered by `init` within Pattern Manager.

---

<img width="469" alt="editor_custom-categories-still-available" src="https://user-images.githubusercontent.com/108079556/230447648-7e70dd03-cc3b-423e-9648-387d8e18401b.png">

Pattern and their categories still work normally when adding posts:

<img width="648" alt="posts-add-new_no-current_screen" src="https://user-images.githubusercontent.com/108079556/230447895-e4986deb-5692-458c-94be-d07a21b5a691.png">

And when working outside of the editor view:

<img width="1300" alt="patterns-view_no-current_screen" src="https://user-images.githubusercontent.com/108079556/230447136-b0e6ac5d-d914-4443-b20d-fe9ffa72991b.png">

---

### How to test
<!-- Detailed steps to test this PR. -->
1. Checkout the branch
2. Use both the patterns and editor views to make sure patterns and their categories are registered