### PR TITLE
Allow `wp-modules/` directories to not have a PHP file

### DIFF
--- a/pattern-manager.php
+++ b/pattern-manager.php
@@ -39,10 +39,6 @@ function include_custom_modules() {
 		if ( is_readable( $filepath ) ) {
 			// If the module data exists, load it.
 			require $filepath;
-		} else {
-			// Translators: The name of the module, and the filename that needs to exist inside that module.
-			echo esc_html( sprintf( __( 'The module called "%1$s" has a problem. It needs a file called "%2$s" to exist in its root directory.', 'pattern-manager' ), $module_name, $filename ) );
-			exit;
 		}
 	}
 }


### PR DESCRIPTION
* Allows a `wp-modules/` directory to not have a PHP file
* For Patternception, we need to use `<PatternPreview>` in both `wp-modules/app/` and `wp-modules/editor/`. 
* So like Michael mentioned, it'd be good to create a new module, like `wp-modules/pattern-preview/`

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

### Notes
Phil, maybe this isn't what you had in mind 😄 Feel free to comment when you get back.

Otherwise, we could also put an empty PHP file in the new module.
