### PR TITLE
[DO NOT MERGE] Add space to top of editor view

### DIFF
--- a/wp-modules/editor/css/src/index.scss
+++ b/wp-modules/editor/css/src/index.scss
@@ -1,7 +1,14 @@
 /* stylelint-disable */
-.edit-post-post-status,
-.edit-post-visual-editor__post-title-wrapper {
+.edit-post-post-status {
 	display: none !important;
+}
+
+.edit-post-visual-editor__post-title-wrapper {
+	margin: 2rem 0 0 0 !important;
+
+	h1 {
+		display: none !important;
+	}
 }
 
 /* Hide tags for templates */


### PR DESCRIPTION
In reference to [GF-3777](https://wpengine.atlassian.net/browse/GF-3777?atlOrigin=eyJpIjoiMTE3YjdmOTZjY2Y2NGE2NGI0ZDcwMzVmMDU1ZTFhZDciLCJwIjoiaiJ9) — this PR would add margin back to the top of the editor:

![Screenshot 2023-04-14 at 11 54 57 AM](https://user-images.githubusercontent.com/108079556/232110147-d2e1e9da-3ca0-48da-89ff-b50b11436c6a.png)

---

I do not think we should do this. Seeing margin that does not exist in the pattern while editing is a bit confusing.

But maybe more users will request it. If so, we at least know it's a very simple change.
