### PR TITLE
Remove `attributes` and `supports` from `core/pattern` filtering

### DIFF
--- a/wp-modules/editor/js/src/utils/registerPatternBlock.ts
+++ b/wp-modules/editor/js/src/utils/registerPatternBlock.ts
@@ -11,6 +11,10 @@ export default function registerPatternBlock(
 				title: __( 'PM Pattern Block', 'pattern-manager' ),
 				icon: 'text',
 				category: 'common',
+				supports: {
+					html: false,
+					inserter: true,
+				},
 				parent: [ 'core/post-content' ], // Don't allow this block as a child of another.
 				edit: PatternEdit,
 				save: () => null,


### PR DESCRIPTION
Defers to the`core/pattern` for [attributes](https://github.com/WordPress/gutenberg/blob/05f568f30534d2bfd5bbd050994a19249e1f912f/packages/block-library/src/pattern/block.json#L13-L17)

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

### Documentation
No documentation required.

