### PR TITLE
Enable rendering blocks that depend on the post

### DIFF
--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -296,16 +296,16 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_meta_fields
  * @param array $parsed_block The block to render.
  * @return array The filtered context.
  */
-function add_post_id_to_block_context( $context, $parsed_block ) {
+function add_post_to_block_context( $context, $parsed_block ) {
 	if ( ! filter_input( INPUT_GET, 'pm_pattern_preview' ) ) {
 		return $context;
 	}
 
-	return empty( $context['postId'] ) && should_block_have_post_context( $parsed_block['blockName'] ?? '' )
+	return should_have_post_context( $parsed_block ) && ! has_post_context( $context )
 		? array_merge(
 			$context,
 			[ 'postId' => get_post_id_with_comment() ?? intval( get_option( 'page_on_front' ) ) ]
 		)
 		: $context;
 }
-add_filter( 'render_block_context', __NAMESPACE__ . '\add_post_id_to_block_context', 10, 2 );
+add_filter( 'render_block_context', __NAMESPACE__ . '\add_post_to_block_context', 10, 2 );

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -284,9 +284,13 @@ function enqueue_meta_fields_in_editor() {
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_meta_fields_in_editor' );
 
 /**
- * Enables the Core Comments block to render by adding a 'postId'.
+ * Enables rendering blocks that depend on a post.
  *
- * TODO: Remove if fixed in Core.
+ * Some blocks have a `postId` in their context
+ * so they can render.
+ * Like comment blocks, so they can show comments from the post.
+ * The PM pattern preview doesn't have a global post,
+ * so this adds one to the block's context.
  *
  * @param array $context The rendered block context.
  * @param array $parsed_block The block to render.
@@ -297,7 +301,7 @@ function add_post_id_to_block_context( $context, $parsed_block ) {
 		return $context;
 	}
 
-	return isset( $parsed_block['blockName'] ) && 0 === strpos( $parsed_block['blockName'], 'core/comment' )
+	return empty( $context['postId'] ) && block_should_have_post_context( $parsed_block['blockName'] ?? '' )
 		? array_merge(
 			$context,
 			[ 'postId' => get_post_id_with_comment() ?? intval( get_option( 'page_on_front' ) ) ]

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -289,8 +289,8 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_meta_fields
  * Some blocks have a `postId` in their context
  * so they can render.
  * Like comment blocks, so they can show comments from the post.
- * The PM pattern preview doesn't have a global post,
- * so this adds one to the block's context.
+ * Sometimes, the PM pattern preview doesn't have a global post.
+ * So this adds one to the block's context.
  *
  * @param array $context The rendered block context.
  * @param array $parsed_block The block to render.

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -301,7 +301,7 @@ function add_post_id_to_block_context( $context, $parsed_block ) {
 		return $context;
 	}
 
-	return empty( $context['postId'] ) && block_should_have_post_context( $parsed_block['blockName'] ?? '' )
+	return empty( $context['postId'] ) && should_block_have_post_context( $parsed_block['blockName'] ?? '' )
 		? array_merge(
 			$context,
 			[ 'postId' => get_post_id_with_comment() ?? intval( get_option( 'page_on_front' ) ) ]

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -311,7 +311,8 @@ class UtilsTest extends WP_UnitTestCase {
 				'core/comment',
 				true,
 			],
-			[ 'core/avatar',
+			[
+				'core/avatar',
 				true,
 			],
 		];

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -311,6 +311,9 @@ class UtilsTest extends WP_UnitTestCase {
 				'core/comment',
 				true,
 			],
+			[ 'core/avatar',
+				true,
+			],
 		];
 	}
 

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -299,4 +299,31 @@ class UtilsTest extends WP_UnitTestCase {
 			get_pm_post_ids()
 		);
 	}
+
+	/**
+	 * Gets the data for the test of should_pattern_have_post_context().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_pattern_have_post_context() {
+		return [
+			[
+				'core/comment',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Tests should_pattern_have_post_context.
+	 *
+	 * @dataProvider data_should_pattern_have_post_context
+	 */
+	public function test_should_pattern_have_post_context( $block_name, $expected ) {
+		$this->assertSame(
+			$expected,
+			should_pattern_have_post_context( $block_name )
+		);
+	}
+
 }

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -301,33 +301,32 @@ class UtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the data for the test of should_block_have_post_context().
+	 * Gets the data for the test of should_have_post_context().
 	 *
 	 * @return array[]
 	 */
-	public function data_should_block_have_post_context() {
+	public function data_should_have_post_context() {
 		return [
 			[
-				'core/comment',
+				[ 'blockName' => 'core/comment' ],
 				true,
 			],
 			[
-				'core/avatar',
+				[ 'blockName' => 'core/avatar' ],
 				true,
 			],
 		];
 	}
 
 	/**
-	 * Tests should_block_have_post_context.
+	 * Tests should_have_post_context.
 	 *
-	 * @dataProvider data_should_block_have_post_context
+	 * @dataProvider data_should_have_post_context
 	 */
-	public function test_should_block_have_post_context( $block_name, $expected ) {
+	public function test_should_have_post_context( $block_name, $expected ) {
 		$this->assertSame(
 			$expected,
-			should_block_have_post_context( $block_name )
+			should_have_post_context( $block_name )
 		);
 	}
-
 }

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -308,6 +308,14 @@ class UtilsTest extends WP_UnitTestCase {
 	public function data_should_have_post_context() {
 		return [
 			[
+				[],
+				false,
+			],
+			[
+				[ 'blockName' => 'core/paragraph' ],
+				false,
+			],
+			[
 				[ 'blockName' => 'core/comment' ],
 				true,
 			],

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -301,11 +301,11 @@ class UtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the data for the test of should_pattern_have_post_context().
+	 * Gets the data for the test of should_block_have_post_context().
 	 *
 	 * @return array[]
 	 */
-	public function data_should_pattern_have_post_context() {
+	public function data_should_block_have_post_context() {
 		return [
 			[
 				'core/comment',
@@ -319,14 +319,14 @@ class UtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests should_pattern_have_post_context.
+	 * Tests should_block_have_post_context.
 	 *
-	 * @dataProvider data_should_pattern_have_post_context
+	 * @dataProvider data_should_block_have_post_context
 	 */
-	public function test_should_pattern_have_post_context( $block_name, $expected ) {
+	public function test_should_block_have_post_context( $block_name, $expected ) {
 		$this->assertSame(
 			$expected,
-			should_pattern_have_post_context( $block_name )
+			should_block_have_post_context( $block_name )
 		);
 	}
 

--- a/wp-modules/editor/utils.php
+++ b/wp-modules/editor/utils.php
@@ -175,9 +175,19 @@ function edit_pattern( string $pattern_name ) {
 /**
  * Gets whether a block should have post context.
  *
- * @param string $block_name The name of the block.
+ * @param string $context The context.
  */
-function should_block_have_post_context( string $block_name ): bool {
+function has_post_context( string $context ): bool {
+	return ! empty( $context['postId'] );
+}
+
+/**
+ * Gets whether a block should have post context.
+ *
+ * @param array $block The parsed block block.
+ */
+function should_have_post_context( array $block ): bool {
+	$block_name = $block['blockName'] ?? '';
 	return 0 === strpos( $block_name, 'core/comment' ) ||
 		'core/avatar' === $block_name;
 }

--- a/wp-modules/editor/utils.php
+++ b/wp-modules/editor/utils.php
@@ -171,3 +171,12 @@ function edit_pattern( string $pattern_name ) {
 		)
 	);
 }
+
+/**
+ * Gets whether a block should have post context.
+ *
+ * @param string $block_name The name of the block.
+ */
+function should_block_have_post_context( string $block_name ): bool {
+	return 0 === strpos( $parsed_block['blockName'], 'core/comment' );
+}

--- a/wp-modules/editor/utils.php
+++ b/wp-modules/editor/utils.php
@@ -178,5 +178,6 @@ function edit_pattern( string $pattern_name ) {
  * @param string $block_name The name of the block.
  */
 function should_block_have_post_context( string $block_name ): bool {
-	return 0 === strpos( $parsed_block['blockName'], 'core/comment' );
+	return 0 === strpos( $block_name, 'core/comment' ) ||
+		'core/avatar' === $block_name;
 }


### PR DESCRIPTION
Some blocks depend on the post. Like 'Post Title' and 'Avatar.'

But sometimes in the PM Pattern Preview, there is no global post.

So the block has no `$context['postId']`, and there's a PHP notice from rendering the block:

<img width="1024" alt="Screenshot 2023-05-03 at 12 30 01 PM" src="https://user-images.githubusercontent.com/4063887/236013425-c8ca3e15-aca3-4ce1-8aae-ad33c05febfb.png">

This PR adds a `$context['postId']` when needed.



## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->

### Related Issues
Fixes [GF-3778](https://wpengine.atlassian.net/browse/GF-3778)

### How to test
<!-- Detailed steps to test this PR. -->
1. Activate Twenty Twentythree (this is already fixed on at least 1 Genesis theme)
2. Create a new pattern
3. Add an 'Avatar' block
4. Publish the pattern
5. Click the WP icon in the upper left
6. Look at the preview of the pattern
7. Expected: it shows an avatar: 

<img width="752" alt="Screenshot 2023-05-03 at 12 33 25 PM" src="https://user-images.githubusercontent.com/4063887/236011480-b5421d2f-7340-4a2a-b825-0b6ad4637c13.png">


Before: it showed a PHP notice:

<img width="1024" alt="Screenshot 2023-05-03 at 12 30 01 PM" src="https://user-images.githubusercontent.com/4063887/236010630-f3cf04b3-4485-4ccf-ac81-fb8e8cf9a7ae.png">


### Notes & Screenshots
<!-- Additional information for reviewers. -->
