### PR TITLE
Allow saving post meta when the pattern name doesn't match the title (many themes)

### DIFF
--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -126,8 +126,8 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 			get_pattern_defaults(),
 			$pattern ? $pattern : [],
 			[
-				'name'    => $pattern_name,
 				$meta_key => $meta_value,
+				'name'    => $pattern_name,
 			]
 		)
 	);

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace PatternManager\Editor;
 
 use WP_Post;
-use WP_REST_Request;
 use function PatternManager\GetWpFilesystem\get_wp_filesystem_api;
 use function PatternManager\PatternDataHandlers\get_pattern_by_name;
 use function PatternManager\PatternDataHandlers\get_pattern_defaults;
@@ -48,10 +47,9 @@ add_action( 'the_post', __NAMESPACE__ . '\populate_pattern_from_file' );
  * Saves the pattern to the .php file.
  *
  * @param int $post_id The post ID.
- * @param WP_REST_Request $request The full request.
  * @param WP_Post $post The post.
  */
-function save_pattern_to_file( WP_Post $post, WP_REST_Request $request ) {
+function save_pattern_to_file( WP_Post $post ) {
 	if ( get_pattern_post_type() !== $post->post_type ) {
 		return;
 	}
@@ -61,12 +59,12 @@ function save_pattern_to_file( WP_Post $post, WP_REST_Request $request ) {
 		array_merge(
 			$pattern ? $pattern : [],
 			[
-				'name'    => $post->post_name,
 				'content' => $post->post_content,
+				'name'    => $post->post_name,
 			],
-			isset( $request['title'] )
-				? [ 'title' => sanitize_text_field( $request['title'] ) ]
-				: [],
+			$post->post_title
+				? [ 'title' => $post->post_title ]
+				: []
 		)
 	);
 
@@ -81,7 +79,7 @@ function save_pattern_to_file( WP_Post $post, WP_REST_Request $request ) {
 
 	tree_shake_theme_images( get_wp_filesystem_api(), 'copy_dir' );
 }
-add_action( 'rest_after_insert_' . get_pattern_post_type(), __NAMESPACE__ . '\save_pattern_to_file', 10, 2 );
+add_action( 'rest_after_insert_' . get_pattern_post_type(), __NAMESPACE__ . '\save_pattern_to_file' );
 
 /**
  * Saves a meta value to the pattern file, instead of the DB.

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -122,21 +122,15 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 	}
 
 	return update_pattern(
-		$pattern
-			? array_merge(
-				$pattern,
-				[
-					$meta_key => $meta_value,
-				]
-			)
-			: array_merge(
-				get_pattern_defaults(),
-				[
-					'name'  => $pattern_name,
-					'title' => $post->post_title,
-				],
-				[ $meta_key => $meta_value ]
-			)
+		array_merge(
+			get_pattern_defaults(),
+			$pattern ? $pattern : [],
+			[
+				'name'  => $pattern_name,
+				'title' => $post->post_title,
+			],
+			[ $meta_key => $meta_value ]
+		)
 	);
 }
 add_filter( 'update_post_metadata', __NAMESPACE__ . '\save_metadata_to_pattern_file', 10, 4 );

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -68,7 +68,7 @@ function save_pattern_to_file( WP_Post $post ) {
 		)
 	);
 
-	// Removes the post content, as it should be saved in the pattern .php file.
+	// Remove pattern data from the post, as it was written to the pattern .php file.
 	wp_update_post(
 		[
 			'ID'           => $post->ID,

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -74,6 +74,7 @@ function save_pattern_to_file( WP_Post $post, WP_REST_Request $request ) {
 	wp_update_post(
 		[
 			'ID'           => $post->ID,
+			'post_title'   => '',
 			'post_content' => '',
 		]
 	);

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -122,15 +122,21 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 	}
 
 	return update_pattern(
-		array_merge(
-			get_pattern_defaults(),
-			$pattern ? $pattern : [],
-			[
-				'name'  => $pattern_name,
-				'title' => $post->post_title,
-			],
-			[ $meta_key => $meta_value ]
-		)
+		$pattern
+			? array_merge(
+				$pattern,
+				[
+					$meta_key => $meta_value,
+				]
+			)
+			: array_merge(
+				get_pattern_defaults(),
+				[
+					'name'  => $pattern_name,
+					'title' => $post->post_title,
+				],
+				[ $meta_key => $meta_value ]
+			)
 	);
 }
 add_filter( 'update_post_metadata', __NAMESPACE__ . '\save_metadata_to_pattern_file', 10, 4 );

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -126,8 +126,8 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 			get_pattern_defaults(),
 			$pattern ? $pattern : [],
 			[
-				$meta_key => $meta_value,
 				'name'    => $pattern_name,
+				$meta_key => $meta_value,
 			]
 		)
 	);

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -126,10 +126,9 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 			get_pattern_defaults(),
 			$pattern ? $pattern : [],
 			[
-				'name'  => $pattern_name,
-				'title' => $post->post_title,
-			],
-			[ $meta_key => $meta_value ]
+				'name'    => $pattern_name,
+				$meta_key => $meta_value,
+			]
 		)
 	);
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
Fixes a [bug I introduced](https://github.com/studiopress/pattern-manager/pull/106/files#diff-8ba31aa77fc662d19b7f20a487d3c2e0d83ac9ab99b843479f7ddae96b0649edL131-R133) that prevented editing meta in patterns not created with PM (patterns where the slug doesn't match the title).

I released this bug last week in [0.1.7](https://github.com/studiopress/pattern-manager/releases/tag/0.1.7)

### How to test
Thanks to Jen and Phil for these
1. Activate [Frost](https://github.com/wpengine/frost) (or most themes with pre-existing patterns)
2. Edit a pattern from the theme (not a pattern you created)
3. Only add a category
4. Save the pattern and reload
5. Expected: The pattern has the category you added:

<img width="1044" alt="Screenshot 2023-05-04 at 11 32 31 AM" src="https://user-images.githubusercontent.com/4063887/236283595-fbad80e3-cb95-4abd-8ce2-c49356dda235.png">


6. Before this PR: there was nothing in the editor:

<img width="859" alt="Screenshot 2023-05-04 at 10 33 03 AM" src="https://user-images.githubusercontent.com/4063887/236272885-158156f4-7e05-4df3-92b3-369b08b20a35.png">


Frost didn't cause this bug, it revealed it. 