### PR TITLE
Handle block supports by rendering the same way FSE themes do

### DIFF
--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -36,6 +36,9 @@ function display_block_pattern_preview() {
 
 	// Mock a post object with the pattern content as the body.
 	mock_pattern_preview_post_object( $pattern['content'] );
+	
+	// This will process block supports using the Style Engine in WP core. See wp-includes/template-canvas.php.
+	$template_html = get_the_block_template_html();
 
 	// Helps to handle cases like Genesis themes, who enqueue their stylesheets using genesis_meta.
 	do_action( 'patternmanager_before_pattern_preview_wp_head' );
@@ -48,7 +51,7 @@ function display_block_pattern_preview() {
 
 	do_action( 'patternmanager_before_pattern_preview' );
 
-	the_content();
+	echo $template_html; // phpcs:ignore WordPress.Security.EscapeOutput
 
 	do_action( 'patternmanager_after_pattern_preview' );
 
@@ -68,7 +71,7 @@ add_action( 'wp', __NAMESPACE__ . '\display_block_pattern_preview', PHP_INT_MAX 
  * @param string $pattern_content The block pattern raw html.
  */
 function mock_pattern_preview_post_object( $pattern_content ) {
-	global $wp, $wp_query;
+	global $wp, $wp_query, $_wp_current_template_content;
 
 	$post_id              = -998; // negative ID, to avoid clash with a valid post.
 	$post                 = new \stdClass();
@@ -130,4 +133,6 @@ function mock_pattern_preview_post_object( $pattern_content ) {
 	// Update globals.
 	$GLOBALS['wp_query'] = $wp_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	$wp->register_globals();
+	
+	$_wp_current_template_content = $pattern_content;
 }

--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -36,7 +36,7 @@ function display_block_pattern_preview() {
 
 	// Mock a post object with the pattern content as the body.
 	mock_pattern_preview_post_object( $pattern['content'] );
-	
+
 	// This will process block supports using the Style Engine in WP core. See wp-includes/template-canvas.php.
 	$template_html = get_the_block_template_html();
 
@@ -133,6 +133,7 @@ function mock_pattern_preview_post_object( $pattern_content ) {
 	// Update globals.
 	$GLOBALS['wp_query'] = $wp_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	$wp->register_globals();
-	
-	$_wp_current_template_content = $pattern_content;
+
+	// Back-fill the variable core uses to render post content. See the core function called get_the_block_template_html.
+	$_wp_current_template_content = $pattern_content; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
WordPress core doesn't use `the_content()` to render block content. Rather it uses [get_the_block_template_html](https://github.com/WordPress/wordpress-develop/blob/d73323e96944a9dbd16ef8edc9c055b1cbc7b735/src/wp-includes/template-canvas.php#L12). By using this instead of `the_content` it means that the block supports get rendered. 

The new Style Engine in WordPress is a long and arduous process to trace through, but this is the end result: using `the_content` means block supports don't work. Using `get_the_block_template_html` means they do. 

Relevant lines of code in WP core (was helpful for debug backtracing to find differences):
https://github.com/WordPress/wordpress-develop/blob/d73323e96944a9dbd16ef8edc9c055b1cbc7b735/src/wp-includes/script-loader.php#L3053

### How to test
1. Load the Frost theme and check the pattern previews. On `main` they will still show alignments missing and incorrect. On this branch, they should be fixed. 
2. Load a non FSE theme as well to make sure the pattern previews are still rockin'.
