### PR TITLE
Bring back Patternception back for the next release

### DIFF
--- a/wp-modules/editor/js/src/index.js
+++ b/wp-modules/editor/js/src/index.js
@@ -6,8 +6,8 @@ import BackButton from './components/BackButton';
 import PatternManagerMetaControls from './components/PatternManagerMetaControls';
 import changeWords from './utils/changeWords';
 import preventTransform from './utils/preventTransform';
-import registerPatternBlock from './utils/registerPatternBlock';
 import receiveActiveTheme from './utils/receiveActiveTheme';
+import registerPatternBlock from "./utils/registerPatternBlock";
 
 registerPlugin( 'pattern-manager-postmeta-for-patterns', {
 	icon: null,

--- a/wp-modules/editor/js/src/index.js
+++ b/wp-modules/editor/js/src/index.js
@@ -5,6 +5,8 @@ import { registerPlugin } from '@wordpress/plugins';
 import BackButton from './components/BackButton';
 import PatternManagerMetaControls from './components/PatternManagerMetaControls';
 import changeWords from './utils/changeWords';
+import preventTransform from './utils/preventTransform';
+import registerPatternBlock from './utils/registerPatternBlock';
 import receiveActiveTheme from './utils/receiveActiveTheme';
 
 registerPlugin( 'pattern-manager-postmeta-for-patterns', {
@@ -18,6 +20,16 @@ registerPlugin( 'pattern-manager-back-button', {
 } );
 
 addFilter( 'i18n.gettext', 'pattern-manager/changeWords', changeWords );
+addFilter(
+	'blocks.registerBlockType',
+	'pattern-manager/preventTransform',
+	preventTransform
+);
+addFilter(
+	'blocks.registerBlockType',
+	'pattern-manager/registerPatternBlock',
+	registerPatternBlock
+);
 addAction(
 	'heartbeat.tick',
 	'pattern-manager/checkActiveTheme',

--- a/wp-modules/editor/js/src/index.js
+++ b/wp-modules/editor/js/src/index.js
@@ -7,7 +7,7 @@ import PatternManagerMetaControls from './components/PatternManagerMetaControls'
 import changeWords from './utils/changeWords';
 import preventTransform from './utils/preventTransform';
 import receiveActiveTheme from './utils/receiveActiveTheme';
-import registerPatternBlock from "./utils/registerPatternBlock";
+import registerPatternBlock from './utils/registerPatternBlock';
 
 registerPlugin( 'pattern-manager-postmeta-for-patterns', {
 	icon: null,


### PR DESCRIPTION
### Summary of changes
Brings back the Patternception back for the next release

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

### Notes & Screenshots
We removed registration of the Patternception block for the last release.

The code is already there, this just brings back registration of the block.
