### PR TITLE
Bump the version to `0.2.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Yes, you will need to have WordPress 6.1 or later installed to take advantage of
 
 ## Changelog
 
+### 0.2.0
+* Add 'PM Pattern Block' to render a pattern in a pattern.
+
 ### 0.1.8
 * Fix some issues with block pattern previews.
 * Fix a bug with editing pre-existing patterns.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Donate link: https://wpengine.com
 Tags: pattern, patterns, pattern design, pattern builder, block patterns
 Requires at least: 6.1
 Tested up to: 6.2
-Stable tag: 0.1.8
+Stable tag: 0.2.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Yes, you will need to have WordPress 6.1 or later installed to take advantage of
 ## Changelog
 
 ### 0.2.0
-* Add 'PM Pattern Block' to render a pattern in a pattern.
+* Add 'Pattern Block' to render a pattern in a pattern.
 
 ### 0.1.8
 * Fix some issues with block pattern previews.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
 	"name": "pattern-manager",
-	"version": "0.1.8",
+	"version": "0.2.0",
 	"lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pattern-manager",
-	"version": "0.1.8",
+	"version": "0.2.0",
 	"license": "GPL-2.0-or-later",
 	"repository": {
 		"type": "git",

--- a/pattern-manager.php
+++ b/pattern-manager.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Pattern Manager
  * Description: Create and maintain patterns.
- * Version: 0.1.8
+ * Version: 0.2.0
  * Author: WP Engine
  * Author URI: wpengine.com
  * Text Domain: pattern-manager


### PR DESCRIPTION
### Summary of changes
* Bumps the version to `0.2.0` for the release

### Related Issues
Fixes [GF-3789](https://wpengine.atlassian.net/browse/GF-3789)
<!-- See #xxx. -->

### How to test
Not needed