### PR TITLE
Fix/block name

### DIFF
--- a/wp-modules/editor/js/src/components/PatternEdit/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternEdit/index.tsx
@@ -149,10 +149,7 @@ export default function PatternEdit( {
 					<PatternInspector />
 					<Placeholder
 						icon={ image }
-						label={ __(
-							'Pattern Block',
-							'pattern-manager'
-						) }
+						label={ __( 'Pattern Block', 'pattern-manager' ) }
 						instructions={ __(
 							'Build a multi-pattern layout with more than one Pattern Block.',
 							'pattern-manager'

--- a/wp-modules/editor/js/src/components/PatternEdit/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternEdit/index.tsx
@@ -154,7 +154,7 @@ export default function PatternEdit( {
 							'pattern-manager'
 						) }
 						instructions={ __(
-							'Build a multi-pattern layout with available patterns',
+							'Build a multi-pattern layout with more than one Pattern Block.',
 							'pattern-manager'
 						) }
 					>

--- a/wp-modules/editor/js/src/components/PatternEdit/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternEdit/index.tsx
@@ -150,7 +150,7 @@ export default function PatternEdit( {
 					<Placeholder
 						icon={ image }
 						label={ __(
-							'Pattern Manager Block',
+							'Pattern Block',
 							'pattern-manager'
 						) }
 						instructions={ __(

--- a/wp-modules/editor/js/src/utils/filterOutPatterns.ts
+++ b/wp-modules/editor/js/src/utils/filterOutPatterns.ts
@@ -3,7 +3,7 @@ import hasPmPatternBlock from './hasPmPatternBlock';
 import type { Pattern, Patterns } from '../types';
 
 /**
- * Removes patterns that have a PM Pattern Block that references the current pattern.
+ * Removes patterns that have a Pattern Block that references the current pattern.
  * They cause an infinite loop.
  */
 export default function filterOutPatterns(

--- a/wp-modules/editor/js/src/utils/preventTransform.ts
+++ b/wp-modules/editor/js/src/utils/preventTransform.ts
@@ -43,7 +43,7 @@ function removeWildcard( from: Transform[] ) {
 	} );
 }
 
-/** Disallows transforming the PM Pattern Block to 'core/columns' or 'core/group'. */
+/** Disallows transforming the Pattern Block to 'core/columns' or 'core/group'. */
 export default function preventTransform(
 	settings: { transforms: Transforms } & Record< string, unknown >,
 	name: string

--- a/wp-modules/editor/js/src/utils/registerPatternBlock.ts
+++ b/wp-modules/editor/js/src/utils/registerPatternBlock.ts
@@ -8,9 +8,10 @@ export default function registerPatternBlock(
 	return name === 'core/pattern'
 		? {
 				...settings,
-				title: __( 'PM Pattern Block', 'pattern-manager' ),
+				title: __( 'Pattern Block', 'pattern-manager' ),
 				icon: 'text',
 				category: 'common',
+				description: 'Show a block pattern.',
 				supports: {
 					html: false,
 					inserter: true,

--- a/wp-modules/editor/js/src/utils/registerPatternBlock.ts
+++ b/wp-modules/editor/js/src/utils/registerPatternBlock.ts
@@ -11,7 +11,10 @@ export default function registerPatternBlock(
 				title: __( 'Pattern Block', 'pattern-manager' ),
 				icon: 'text',
 				category: 'common',
-				description: 'Show a block pattern.',
+				description: __(
+					'Build a multi-pattern layout with more than one Pattern Block.',
+					'pattern-manager'
+				),
 				supports: {
 					html: false,
 					inserter: true,

--- a/wp-modules/editor/js/src/utils/test/hasPmPatternBlock.ts
+++ b/wp-modules/editor/js/src/utils/test/hasPmPatternBlock.ts
@@ -73,7 +73,7 @@ describe( 'hasPmPatternBlock', () => {
 			true,
 		],
 	] )(
-		'should get whether there is a PM Pattern Block',
+		'should get whether there is a Pattern Block',
 		( blocks, patternSlug, expected ) => {
 			expect( hasPmPatternBlock( blocks, patternSlug ) ).toEqual(
 				expected

--- a/wp-modules/editor/js/src/utils/test/registerPatternBlock.ts
+++ b/wp-modules/editor/js/src/utils/test/registerPatternBlock.ts
@@ -10,12 +10,12 @@ describe( 'registerPatternBlock', () => {
 		).toEqual( { name: 'core/paragraph' } );
 	} );
 
-	it( 'returns the PM Pattern Block instead of the core one', () => {
+	it( 'returns the Pattern Block instead of the core one', () => {
 		const actual = registerPatternBlock(
 			{ name: 'core/pattern' },
 			'core/pattern'
 		);
-		expect( actual.title ).toBe( 'PM Pattern Block' );
+		expect( actual.title ).toBe( 'Pattern Block' );
 		expect( actual.supports.inserter ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
Updates the block name, making sure they match.
Updates to description, making sure they match.

<img width="1763" alt="Screenshot 2023-05-10 at 12 28 34 PM" src="https://github.com/studiopress/pattern-manager/assets/1271053/7c529056-a3b9-414b-babf-d27414dbe36a">

### How to test
<!-- Detailed steps to test this PR. -->
1. View the Pattern Block in the editor, sidebar, and inserters.
2. Make sure block name and description match.

Not married to the description :)

Feel free to edit since I'll be out until next week.
