### PR TITLE
Allow saving meta for a new pattern with no content

### DIFF
--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -127,6 +127,7 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 			get_pattern_defaults(),
 			$pattern ? $pattern : [],
 			[
+				'title'   => $pattern['title'] ?? $post->post_title,
 				'name'    => $pattern_name,
 				$meta_key => $meta_value,
 			]

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -125,9 +125,8 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 	return update_pattern(
 		array_merge(
 			get_pattern_defaults(),
-			$pattern ? $pattern : [],
+			$pattern ? $pattern : [ 'title' => $post->post_title ],
 			[
-				'title'   => $pattern['title'] ?? $post->post_title,
 				'name'    => $pattern_name,
 				$meta_key => $meta_value,
 			]

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -123,9 +123,6 @@ function format_pattern_data( $pattern_data, $file ) {
 	include $file;
 	$pattern_data['content'] = ob_get_clean();
 
-	if ( ! $pattern_data['content'] ) {
-		return false;
-	}
 	return $pattern_data;
 }
 


### PR DESCRIPTION
### Summary of changes
Allows saving meta, like Categories, for a new pattern that has no content:

<img width="897" alt="Screenshot 2023-05-15 at 12 27 33 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/e60e9cc1-ef90-4514-b84b-57b7c2f54a07">

------

Before, the meta didn't save after publishing if there wasn't content: 
<img width="897" alt="Screenshot 2023-05-15 at 12 27 33 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/de338a09-a46d-46ec-bcfe-5ade555c90dd">

### Related Issues
Fixes https://github.com/studiopress/pattern-manager/issues/166
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
See the [To Reproduce steps](https://github.com/studiopress/pattern-manager/issues/166) in PR 166

Pattern saving has become whack-a-mole 😄 
