### PR TITLE
Fix icon not centering

### DIFF
--- a/wp-modules/editor/js/src/components/PatternEdit/index.tsx
+++ b/wp-modules/editor/js/src/components/PatternEdit/index.tsx
@@ -127,6 +127,7 @@ export default function PatternEdit( {
 							fontSize: '16px',
 							padding: '5px',
 							border: 'solid 1px rgba(0,0,0,.1)',
+							boxSizing: 'border-box',
 						} }
 					>
 						<Icon


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->
Fixes patternception lock icon display problems 

### How to test
<!-- Detailed steps to test this PR. -->
1. Create a pattern using the Pattern Block.
2. Make sure the lock icon is centered within its circle.

### Notes & Screenshots

<!-- Additional information for reviewers. -->
Before

<img width="81" alt="Screenshot 2023-05-15 at 10 50 33 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/a582756b-525b-483a-9489-22dfdfeea09e">

After
<img width="49" alt="Screenshot 2023-05-15 at 10 50 48 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/6398cc51-7aec-4eaa-9407-a48927586a28">
