### PR TITLE
Change any instance of a pattern’s name to be “slug”

### DIFF
--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -62,7 +62,7 @@ export default function PatternGrid( {
 											url={
 												siteUrl +
 												'?pm_pattern_preview=' +
-												patternData.name
+												patternData.slug
 											}
 											viewportWidth={
 												patternData.viewportWidth ||

--- a/wp-modules/app/js/src/components/Patterns/PatternGridActions.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGridActions.tsx
@@ -46,7 +46,7 @@ export default function PatternGridActions( { patternData }: Props ) {
 						__( 'Duplicate %1$s', 'pattern-manager' ),
 						patternData.title
 					) }
-					href={ `${ patternManager.siteUrl }/wp-admin/admin.php?post_type=pm_pattern&action=duplicate&name=${ patternData.name }` }
+					href={ `${ patternManager.siteUrl }/wp-admin/admin.php?post_type=pm_pattern&action=duplicate&name=${ patternData.slug }` }
 				>
 					<Icon
 						className="item-action-icon"
@@ -76,7 +76,7 @@ export default function PatternGridActions( { patternData }: Props ) {
 								)
 							)
 						) {
-							patterns.deletePattern( patternData.name );
+							patterns.deletePattern( patternData.slug );
 						}
 					} }
 				>

--- a/wp-modules/app/js/src/hooks/usePatterns.ts
+++ b/wp-modules/app/js/src/hooks/usePatterns.ts
@@ -8,7 +8,7 @@ import type { Pattern, Patterns } from '../types';
 export default function usePatterns( initialPatterns: Patterns ) {
 	const [ patternsData, setPatternsData ] = useState( initialPatterns );
 
-	function deletePattern( patternName: Pattern[ 'name' ] ) {
+	function deletePattern( patternName: Pattern[ 'slug' ] ) {
 		setPatternsData( removePattern( patternName, patternsData ) );
 		return fetch( patternManager.apiEndpoints.deletePatternEndpoint, {
 			method: 'DELETE',

--- a/wp-modules/app/js/src/utils/getUniquePatternCategories.ts
+++ b/wp-modules/app/js/src/utils/getUniquePatternCategories.ts
@@ -51,7 +51,7 @@ export default function getUniquePatternCategories(
 					} ),
 			],
 			// Sort by name property.
-			'name'
+			'slug'
 		),
 	];
 }

--- a/wp-modules/app/js/src/utils/removePattern.ts
+++ b/wp-modules/app/js/src/utils/removePattern.ts
@@ -1,7 +1,7 @@
 import type { Pattern, Patterns } from '../types';
 
 export default function removePattern(
-	nameToDelete: Pattern[ 'name' ],
+	nameToDelete: Pattern[ 'slug' ],
 	existingPatterns: Patterns
 ) {
 	const {

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -54,12 +54,12 @@ function register_pattern_post_type() {
 
 	register_post_meta(
 		$post_type_key,
-		'name',
+		'slug',
 		array(
 			'show_in_rest' => true,
 			'single'       => true,
 			'type'         => 'string',
-			'default'      => get_pattern_defaults()['name'],
+			'default'      => get_pattern_defaults()['slug'],
 		)
 	);
 

--- a/wp-modules/editor/js/src/components/SidebarPanels/TitlePanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/TitlePanel.tsx
@@ -13,7 +13,7 @@ import type { Pattern } from '../../types';
 function isTitleTaken(
 	patternTitle: string,
 	currentName: string,
-	patternNames: Array< Pattern[ 'name' ] >
+	patternNames: Array< Pattern[ 'slug' ] >
 ) {
 	const newSlug = convertToSlug( patternTitle );
 	return patternNames.includes( newSlug ) && newSlug !== currentName;
@@ -47,22 +47,12 @@ export default function TitlePanel( {
 				value={ title }
 				onChange={ ( newTitle: typeof title ) => {
 					editPost( { title: newTitle } );
-					handleChange( 'name', convertToSlug( newTitle ) );
+					handleChange( 'slug', convertToSlug( newTitle ) );
 
 					if ( ! newTitle ) {
 						lockPostSaving();
 						const newErrorMessage = __(
 							'Please enter a title.',
-							'pattern-manager'
-						);
-						speak( newErrorMessage, 'assertive' );
-						setErrorMessage( newErrorMessage );
-					} else if (
-						isTitleTaken( newTitle, currentName, patternNames )
-					) {
-						lockPostSaving();
-						const newErrorMessage = __(
-							'Please enter a unique title.',
 							'pattern-manager'
 						);
 						speak( newErrorMessage, 'assertive' );

--- a/wp-modules/editor/js/src/components/SidebarPanels/TitlePanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/TitlePanel.tsx
@@ -57,6 +57,16 @@ export default function TitlePanel( {
 						);
 						speak( newErrorMessage, 'assertive' );
 						setErrorMessage( newErrorMessage );
+					} else if (
+						isTitleTaken( newTitle, currentName, patternNames )
+					) {
+						lockPostSaving();
+						const newErrorMessage = __(
+							'Please enter a unique title.',
+							'pattern-manager'
+						);
+						speak( newErrorMessage, 'assertive' );
+						setErrorMessage( newErrorMessage );
 					} else {
 						unlockPostSaving();
 						setErrorMessage( '' );

--- a/wp-modules/editor/js/src/components/SidebarPanels/types.ts
+++ b/wp-modules/editor/js/src/components/SidebarPanels/types.ts
@@ -17,7 +17,7 @@ type AdditionalTypes = {
 	categoryOptions: ReturnType< typeof usePatternData >[ 'queriedCategories' ];
 	currentName: ReturnType< typeof useSavedPostData >[ 'currentName' ];
 	errorMessage: string;
-	patternNames: Array< PatternPostData[ 'name' ] >;
+	patternNames: Array< PatternPostData[ 'slug' ] >;
 	postTypeOptions: ReturnType< typeof usePatternData >[ 'queriedPostTypes' ];
 	setErrorMessage: Dispatch< SetStateAction< string > >;
 };

--- a/wp-modules/editor/js/src/hooks/useSave.ts
+++ b/wp-modules/editor/js/src/hooks/useSave.ts
@@ -5,7 +5,7 @@ import { patternManager } from '../globals';
 import type { Pattern, SelectQuery } from '../types';
 
 export default function useSave(
-	setPatternNames: ( patternNames: Array< Pattern[ 'name' ] > ) => void
+	setPatternNames: ( patternNames: Array< Pattern[ 'slug' ] > ) => void
 ) {
 	const isSavingPost = useSelect( ( select: SelectQuery ) => {
 		return select( 'core/editor' ).isSavingPost();

--- a/wp-modules/editor/js/src/utils/filterOutPatterns.ts
+++ b/wp-modules/editor/js/src/utils/filterOutPatterns.ts
@@ -8,7 +8,7 @@ import type { Pattern, Patterns } from '../types';
  */
 export default function filterOutPatterns(
 	patterns: Patterns,
-	patternName: Pattern[ 'name' ]
+	patternName: Pattern[ 'slug' ]
 ) {
 	return Object.entries( patterns ).reduce(
 		( accumulator, [ key, pattern ] ) => {
@@ -18,7 +18,7 @@ export default function filterOutPatterns(
 					'core/pattern',
 					parse( pattern.content ),
 					patternName
-				) && pattern.name !== patternName
+				) && pattern.slug !== patternName
 					? { [ key ]: pattern }
 					: {} ),
 			};

--- a/wp-modules/editor/js/src/utils/hasBlock.ts
+++ b/wp-modules/editor/js/src/utils/hasBlock.ts
@@ -3,7 +3,7 @@ import type { Block, Pattern } from '../types';
 export default function hasBlock(
 	blockName: String,
 	blocks: Block[],
-	patternName: Pattern[ 'name' ]
+	patternName: Pattern[ 'slug' ]
 ) {
 	return blocks.some( ( block ) => {
 		return (

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -12,7 +12,7 @@ namespace PatternManager\Editor;
 
 use WP_Post;
 use function PatternManager\GetWpFilesystem\get_wp_filesystem_api;
-use function PatternManager\PatternDataHandlers\get_pattern_by_name;
+use function PatternManager\PatternDataHandlers\get_pattern_by_slug;
 use function PatternManager\PatternDataHandlers\get_pattern_defaults;
 use function PatternManager\PatternDataHandlers\get_theme_patterns;
 use function PatternManager\PatternDataHandlers\delete_pattern;
@@ -33,7 +33,7 @@ function populate_pattern_from_file( $post ) {
 		return;
 	}
 
-	$pattern = get_pattern_by_name( $post->post_name );
+	$pattern = get_pattern_by_slug( $post->post_name );
 	if ( ! $pattern ) {
 		return;
 	}
@@ -54,13 +54,13 @@ function save_pattern_to_file( WP_Post $post ) {
 		return;
 	}
 
-	$pattern = get_pattern_by_name( $post->post_name );
+	$pattern = get_pattern_by_slug( $post->post_name );
 	update_pattern(
 		array_merge(
 			$pattern ? $pattern : [],
 			[
 				'content' => $post->post_content,
-				'name'    => $post->post_name,
+				'slug'    => $post->post_name,
 			],
 			$post->post_title
 				? [ 'title' => $post->post_title ]
@@ -102,14 +102,14 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 		return $override;
 	}
 
-	if ( 'name' === $meta_key && ! $meta_value ) {
+	if ( 'slug' === $meta_key && ! $meta_value ) {
 		return $override;
 	}
 
 	$pattern_name = $post->post_name;
-	$pattern      = get_pattern_by_name( $pattern_name );
+	$pattern      = get_pattern_by_slug( $pattern_name );
 
-	if ( 'name' === $meta_key ) {
+	if ( 'slug' === $meta_key ) {
 		wp_update_post(
 			[
 				'ID'        => $post_id,
@@ -127,7 +127,7 @@ function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_va
 			get_pattern_defaults(),
 			$pattern ? $pattern : [ 'title' => $post->post_title ],
 			[
-				'name'    => $pattern_name,
+				'slug'    => $pattern_name,
 				$meta_key => $meta_value,
 			]
 		)
@@ -150,7 +150,7 @@ function get_metadata_from_pattern_file( $override, $post_id, $meta_key, $is_sin
 		return $override;
 	}
 
-	$pattern = get_pattern_by_name( $post->post_name );
+	$pattern = get_pattern_by_slug( $post->post_name );
 	if ( isset( $pattern[ $meta_key ] ) ) {
 		return $is_single ? $pattern[ $meta_key ] : [ $pattern[ $meta_key ] ];
 	}
@@ -172,11 +172,11 @@ function redirect_pattern_actions() {
 	}
 
 	if ( 'duplicate' === filter_input( INPUT_GET, 'action' ) ) {
-		duplicate_pattern( filter_input( INPUT_GET, 'name' ) );
+		duplicate_pattern( filter_input( INPUT_GET, 'slug' ) );
 	}
 
 	if ( 'edit-pattern' === filter_input( INPUT_GET, 'action' ) ) {
-		edit_pattern( filter_input( INPUT_GET, 'name' ) );
+		edit_pattern( filter_input( INPUT_GET, 'slug' ) );
 	}
 }
 add_action( 'admin_init', __NAMESPACE__ . '\redirect_pattern_actions' );

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -98,13 +98,13 @@ class UtilsTest extends WP_UnitTestCase {
 				'my-new-pattern',
 				array(
 					'my-new-pattern' => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 				),
 				array(
-					'name'  => 'my-new-pattern-copied',
+					'slug'  => 'my-new-pattern-copied',
 					'slug'  => 'my-new-pattern-copied',
 					'title' => 'My New Pattern (copied)',
 				),
@@ -113,18 +113,18 @@ class UtilsTest extends WP_UnitTestCase {
 				'my-new-pattern',
 				array(
 					'my-new-pattern'        => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-copied' => array(
-						'name'  => 'my-new-pattern-copied',
+						'slug'  => 'my-new-pattern-copied',
 						'slug'  => 'my-new-pattern-copied',
 						'title' => 'My New Pattern (copied)',
 					),
 				),
 				array(
-					'name'  => 'my-new-pattern-copied-1',
+					'slug'  => 'my-new-pattern-copied-1',
 					'slug'  => 'my-new-pattern-copied-1',
 					'title' => 'My New Pattern (copied) 1',
 				),
@@ -133,23 +133,23 @@ class UtilsTest extends WP_UnitTestCase {
 				'my-new-pattern',
 				array(
 					'my-new-pattern'          => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-copied'   => array(
-						'name'  => 'my-new-pattern-copied',
+						'slug'  => 'my-new-pattern-copied',
 						'slug'  => 'my-new-pattern-copied',
 						'title' => 'My New Pattern (copied)',
 					),
 					'my-new-pattern-copied-1' => array(
-						'name'  => 'my-new-pattern-copied-1',
+						'slug'  => 'my-new-pattern-copied-1',
 						'slug'  => 'my-new-pattern-copied-1',
 						'title' => 'My New Pattern (copied) 1',
 					),
 				),
 				array(
-					'name'  => 'my-new-pattern-copied-2',
+					'slug'  => 'my-new-pattern-copied-2',
 					'slug'  => 'my-new-pattern-copied-2',
 					'title' => 'My New Pattern (copied) 2',
 				),
@@ -158,23 +158,23 @@ class UtilsTest extends WP_UnitTestCase {
 				'my-new-pattern',
 				array(
 					'my-new-pattern'          => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-copied'   => array(
-						'name'  => 'my-new-pattern-copied',
+						'slug'  => 'my-new-pattern-copied',
 						'slug'  => 'my-new-pattern-copied',
 						'title' => 'My New Pattern (copied)',
 					),
 					'my-new-pattern-copied-9' => array(
-						'name'  => 'my-new-pattern-copied-9',
+						'slug'  => 'my-new-pattern-copied-9',
 						'slug'  => 'my-new-pattern-copied-9',
 						'title' => 'My New Pattern (copied) 9',
 					),
 				),
 				array(
-					'name'  => 'my-new-pattern-copied-1',
+					'slug'  => 'my-new-pattern-copied-1',
 					'slug'  => 'my-new-pattern-copied-1',
 					'title' => 'My New Pattern (copied) 1',
 				),
@@ -208,7 +208,7 @@ class UtilsTest extends WP_UnitTestCase {
 			array(
 				array(
 					'my-new-pattern' => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
@@ -218,12 +218,12 @@ class UtilsTest extends WP_UnitTestCase {
 			array(
 				array(
 					'my-new-pattern'   => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-1' => array(
-						'name'  => 'my-new-pattern-1',
+						'slug'  => 'my-new-pattern-1',
 						'slug'  => 'my-new-pattern-1',
 						'title' => 'My New Pattern 1',
 					),
@@ -233,17 +233,17 @@ class UtilsTest extends WP_UnitTestCase {
 			array(
 				array(
 					'my-new-pattern'   => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-1' => array(
-						'name'  => 'my-new-pattern-1',
+						'slug'  => 'my-new-pattern-1',
 						'slug'  => 'my-new-pattern-1',
 						'title' => 'My New Pattern 1',
 					),
 					'my-new-pattern-2' => array(
-						'name'  => 'my-new-pattern-2',
+						'slug'  => 'my-new-pattern-2',
 						'slug'  => 'my-new-pattern-2',
 						'title' => 'My New Pattern 2',
 					),
@@ -253,17 +253,17 @@ class UtilsTest extends WP_UnitTestCase {
 			array(
 				array(
 					'my-new-pattern'   => array(
-						'name'  => 'my-new-pattern',
+						'slug'  => 'my-new-pattern',
 						'slug'  => 'my-new-pattern',
 						'title' => 'My New Pattern',
 					),
 					'my-new-pattern-1' => array(
-						'name'  => 'my-new-pattern-1',
+						'slug'  => 'my-new-pattern-1',
 						'slug'  => 'my-new-pattern-1',
 						'title' => 'My New Pattern 1',
 					),
 					'my-new-pattern-9' => array(
-						'name'  => 'my-new-pattern-9',
+						'slug'  => 'my-new-pattern-9',
 						'slug'  => 'my-new-pattern-9',
 						'title' => 'My New Pattern 9',
 					),

--- a/wp-modules/editor/utils.php
+++ b/wp-modules/editor/utils.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace PatternManager\Editor;
 
 use WP_Query;
-use function PatternManager\PatternDataHandlers\get_pattern_by_name;
+use function PatternManager\PatternDataHandlers\get_pattern_by_slug;
 use function PatternManager\PatternDataHandlers\get_theme_patterns;
 use function PatternManager\PatternDataHandlers\update_pattern;
 
@@ -52,7 +52,7 @@ function get_new_pattern_number( string $name, array $all_patterns ): int {
  * @param string $name The pattern name
  * @param array $all_patterns All the patterns.
  * @return array {
- *   'name'  => string,
+ *   'slug'  => string,
  *   'slug'  => string,
  *   'title' => string,
  * } | null
@@ -63,12 +63,12 @@ function get_duplicate_pattern_ids( string $name, array $all_patterns ) {
 		return null;
 	}
 
-	$base_name      = "{$pattern_to_duplicate['name']}-copied";
+	$base_name      = "{$pattern_to_duplicate['slug']}-copied";
 	$base_title     = "{$pattern_to_duplicate['title']} (copied)";
 	$pattern_number = get_new_pattern_number( $base_name, $all_patterns );
 
 	return array(
-		'name'  => $pattern_number ? "{$base_name}-{$pattern_number}" : $base_name,
+		'slug'  => $pattern_number ? "{$base_name}-{$pattern_number}" : $base_name,
 		'slug'  => $pattern_number ? "{$base_name}-{$pattern_number}" : $base_name,
 		'title' => $pattern_number ? "{$base_title} {$pattern_number}" : $base_title,
 	);
@@ -107,8 +107,8 @@ function get_pm_post_ids() {
  * @param string $pattern_name The pattern name to duplicate.
  */
 function duplicate_pattern( string $pattern_name ) {
-	$pattern_to_duplicate  = get_pattern_by_name( sanitize_text_field( $pattern_name ) );
-	$duplicate_pattern_ids = get_duplicate_pattern_ids( $pattern_to_duplicate['name'], get_theme_patterns() );
+	$pattern_to_duplicate  = get_pattern_by_slug( sanitize_text_field( $pattern_name ) );
+	$duplicate_pattern_ids = get_duplicate_pattern_ids( $pattern_to_duplicate['slug'], get_theme_patterns() );
 	if ( ! $duplicate_pattern_ids ) {
 		return;
 	}
@@ -125,7 +125,7 @@ function duplicate_pattern( string $pattern_name ) {
 			wp_insert_post(
 				[
 					'post_type'   => get_pattern_post_type(),
-					'post_name'   => $new_pattern['name'],
+					'post_name'   => $new_pattern['slug'],
 					'post_status' => 'publish',
 				]
 			),

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -252,7 +252,7 @@ function get_pattern_defaults() {
 /**
  * Gets a pattern by its name.
  *
- * @param string $name The pattern name.
+ * @param string $slug The pattern slug.
  * @return array|false
  */
 function get_pattern_by_slug( $slug ) {

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -82,7 +82,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 			'postTypes'     => [ 'wp_block', 'wp_template' ],
 			'inserter'      => true,
 			'content'       => '<!-- wp:paragraph --><p>Here is some content</p><!-- /wp:paragraph -->',
-			'name'          => 'my-new-pattern',
+			'slug'          => 'my-new-pattern',
 		];
 	}
 
@@ -98,7 +98,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 			$this->normalize(
 				construct_pattern_php_file_contents(
 					[
-						'name'  => 'empty',
+						'slug'  => 'empty',
 						'title' => 'Empty',
 					]
 				)
@@ -124,19 +124,19 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests get_pattern_by_name.
+	 * Tests get_pattern_by_slug.
 	 */
-	public function test_get_pattern_by_name_not_found() {
+	public function test_get_pattern_by_slug_not_found() {
 		$this->assertFalse(
-			get_pattern_by_name( 'does-not-exist' )
+			get_pattern_by_slug( 'does-not-exist' )
 		);
 	}
 
 	/**
-	 * Tests get_pattern_by_name.
+	 * Tests get_pattern_by_slug.
 	 */
-	public function test_get_pattern_by_name() {
-		$actual_pattern = get_pattern_by_name( 'my-new-pattern' );
+	public function test_get_pattern_by_slug() {
+		$actual_pattern = get_pattern_by_slug( 'my-new-pattern' );
 
 		$this->assertSame(
 			$this->get_expected_pattern(),

--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -28,7 +28,7 @@ function display_block_pattern_preview() {
 
 	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_pattern_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-	$pattern = \PatternManager\PatternDataHandlers\get_pattern_by_name( $pattern_name );
+	$pattern = \PatternManager\PatternDataHandlers\get_pattern_by_slug( $pattern_name );
 
 	if ( ! isset( $pattern['content'] ) ) {
 		$pattern['content'] = '';


### PR DESCRIPTION
### Summary of changes
We've had some confusion between a pattern's `name` and its `slug`. This PR removes the concept of a pattern's `name` entirely, opting to use the `slug` for everything.

There shouldn't be any functional changes with this.