### PR TITLE
Make sure post_type exists before using it

### DIFF
--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -92,6 +92,11 @@ add_action( 'rest_after_insert_' . get_pattern_post_type(), __NAMESPACE__ . '\sa
  */
 function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_value ) {
 	$post = get_post( $post_id );
+	
+	if ( ! isset( $post->post_type ) ) {
+		return $override;
+	}
+
 	if ( get_pattern_post_type() !== $post->post_type ) {
 		return $override;
 	}

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -92,7 +92,7 @@ add_action( 'rest_after_insert_' . get_pattern_post_type(), __NAMESPACE__ . '\sa
  */
 function save_metadata_to_pattern_file( $override, $post_id, $meta_key, $meta_value ) {
 	$post = get_post( $post_id );
-	
+
 	if ( ! isset( $post->post_type ) ) {
 		return $override;
 	}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
I ran into this error when previewing a pattern. Oddly I wasn't able to re-replicate, but adding a check for this is simple. It likely happens during an auto-save procedure in core, and we don't want to do anything on that anyway, so this simply escaped the hook early if that's the case. 

### How to test
1. Save a pattern. Make sure it works as normal.

### Notes & Screenshots
<img width="1792" alt="Screenshot 2023-05-17 at 2 03 07 PM" src="https://github.com/studiopress/pattern-manager/assets/7538525/482e141a-aeeb-49ea-a794-18bbd4b03e81">

