### PR TITLE
Fix pattern preview heights when on a row by themselves

### DIFF
--- a/wp-modules/app/js/src/components/Patterns/index.scss
+++ b/wp-modules/app/js/src/components/Patterns/index.scss
@@ -189,7 +189,7 @@
 							border-radius: 5px;
 							min-height: 300px;
 							overflow: hidden;
-							height:min-content;
+							height: min-content;
 						}
 
 						.pattern-preview-iframe-inner {

--- a/wp-modules/app/js/src/components/Patterns/index.scss
+++ b/wp-modules/app/js/src/components/Patterns/index.scss
@@ -92,7 +92,7 @@
 				position: relative;
 				box-sizing: border-box;
 				margin-bottom: 50px;
-				height:min-content;
+				height: min-content;
 				min-height: 300px;
 				border: solid 1px #ddd;
 				border-radius: 5px;

--- a/wp-modules/app/js/src/components/Patterns/index.scss
+++ b/wp-modules/app/js/src/components/Patterns/index.scss
@@ -92,6 +92,7 @@
 				position: relative;
 				box-sizing: border-box;
 				margin-bottom: 50px;
+				height:min-content;
 				min-height: 300px;
 				border: solid 1px #ddd;
 				border-radius: 5px;
@@ -188,6 +189,7 @@
 							border-radius: 5px;
 							min-height: 300px;
 							overflow: hidden;
+							height:min-content;
 						}
 
 						.pattern-preview-iframe-inner {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
When a pattern preview is by itself, it takes up 100% of the height available. This PR makes it so that it shrinks down to 300px, while still allowing a longer pattern to show its full height. 

#### Before:

<img width="1591" alt="Screenshot 2023-05-17 at 2 47 19 PM" src="https://github.com/studiopress/pattern-manager/assets/7538525/497568b0-2a43-4817-978c-532936249bb4">

#### After:

<img width="1607" alt="Screenshot 2023-05-17 at 3 05 02 PM" src="https://github.com/studiopress/pattern-manager/assets/7538525/d0e68d81-f007-40f0-9b23-2f1771736d3c">

### Note: this also affects how short patterns show beside long patterns:

#### Before:
<img width="1590" alt="Screenshot 2023-05-17 at 2 47 51 PM" src="https://github.com/studiopress/pattern-manager/assets/7538525/d0fe16c9-534b-4d6a-b77d-22261d646349">

#### After:
<img width="1561" alt="Screenshot 2023-05-17 at 2 50 57 PM" src="https://github.com/studiopress/pattern-manager/assets/7538525/bc4dec69-54b8-47c8-98ce-1a3057e41336">

I spoke with Kam about this and confirmed that while a masonry layout might be preferable, we can iterate to that later if needed.

### How to test
1. On main, using the Frost theme, preview your patterns.
2. Click on the "Portfolio" category, where there's only 1 pattern
3. Notice the height of the preview fill all of the available space
4. Change this this branch
5. Refresh and notice the height maxes-out at 300px high, like other previews.
6. Go back to view all patterns, and notice that patterns higher than 300px still show their full height, but shorter pattern beside max-out at 300px, leaving some empty space beneath them.
