### PR TITLE
[Dont Merge Yet] Fix PHP unit errors with wp-env phpunit container removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"wpps_options": "-n PatternManager -t pattern-manager",
 	"scripts": {
-		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone -b fix/phpunit https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
+		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
 		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p \"${OLDPWD}\";",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"wpps_options": "-n PatternManager -t pattern-manager",
 	"scripts": {
-		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
+		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone -b fix/phpunit https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
 		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p \"${OLDPWD}\";",

--- a/wp-modules/api-data/tests/ApiDataTest.php
+++ b/wp-modules/api-data/tests/ApiDataTest.php
@@ -22,7 +22,7 @@ class ApiDataTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	public function setUp() : void {
 		parent::setUp();
 		add_filter( 'request_filesystem_credentials', '__return_true' );
 		add_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );
@@ -31,7 +31,7 @@ class ApiDataTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function tearDown() {
+	public function tearDown() : void {
 		unset( $GLOBALS['wp_rest_server'] );
 		remove_filter( 'request_filesystem_credentials', '__return_true' );
 		remove_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );

--- a/wp-modules/editor/tests/EditorTest.php
+++ b/wp-modules/editor/tests/EditorTest.php
@@ -37,13 +37,31 @@ class EditorTest extends WP_UnitTestCase {
 	 */
 	public function test_register_pattern_post_type_meta_types() {
 		register_pattern_post_type();
+		
+		$pattern_default_keys = get_pattern_defaults();
+		$registered_keys      = get_registered_meta_keys( 'post', 'pm_pattern' );
+		
+		// Loop through each default key to make sure its type matches what was actually registered by WP.
+		foreach ( $pattern_default_keys as $meta_key => $default_value ) {
 
-		foreach ( array_diff( get_pattern_defaults(), [ 'title' => null ] ) as $meta_key => $default_value ) {
-			$expected_type = get_registered_meta_keys( 'post', 'pm_pattern' )[ $meta_key ]['type'];
+			// The title and content pattern defaults are not registered meta keys, so skip them.
+			if ( 'title' === $meta_key || 'content' === $meta_key ) {
+				continue;
+			}
+
+			$expected_type = $registered_keys[ $meta_key ]['type'];
+			
+			// Fix the typing for numbers.
+			if ( 'number' === $expected_type ) {
+				$expected_type = 'integer';
+			}
+
+			$actual_type = gettype( $default_value );
+			
 			$this->assertSame(
-				'number' === $expected_type ? 'integer' : $expected_type,
-				gettype( $default_value ),
-				"the type of the default for {$meta_key} is wrong"
+				$expected_type,
+				$actual_type,
+				"The type of the default for {$meta_key} is wrong. It should be {$expected_type} but it was {$actual_type}"
 			);
 		}
 	}
@@ -54,11 +72,23 @@ class EditorTest extends WP_UnitTestCase {
 	public function test_register_pattern_post_type_meta_defaults() {
 		register_pattern_post_type();
 
-		foreach ( array_diff( get_pattern_defaults(), [ 'title' => null ] ) as $meta_key => $default_value ) {
+		$pattern_default_keys = get_pattern_defaults();
+		$registered_keys      = get_registered_meta_keys( 'post', 'pm_pattern' );
+
+		// Loop through each default key to make sure its default value matches what was actually registered by WP.
+		foreach ( $pattern_default_keys as $meta_key => $default_value ) {
+
+			// The title and content pattern defaults are not registered meta keys, so skip them.
+			if ( 'title' === $meta_key || 'content' === $meta_key ) {
+				continue;
+			}
+
+			$actual_value = $registered_keys[ $meta_key ]['default'];
+
 			$this->assertSame(
 				$default_value,
-				get_registered_meta_keys( 'post', 'pm_pattern' )[ $meta_key ]['default'],
-				"the default value of {$meta_key} is wrong"
+				$actual_value,
+				"The value of the default for {$meta_key} is wrong."
 			);
 		}
 	}

--- a/wp-modules/editor/tests/EditorTest.php
+++ b/wp-modules/editor/tests/EditorTest.php
@@ -37,10 +37,10 @@ class EditorTest extends WP_UnitTestCase {
 	 */
 	public function test_register_pattern_post_type_meta_types() {
 		register_pattern_post_type();
-		
+
 		$pattern_default_keys = get_pattern_defaults();
 		$registered_keys      = get_registered_meta_keys( 'post', 'pm_pattern' );
-		
+
 		// Loop through each default key to make sure its type matches what was actually registered by WP.
 		foreach ( $pattern_default_keys as $meta_key => $default_value ) {
 
@@ -50,14 +50,14 @@ class EditorTest extends WP_UnitTestCase {
 			}
 
 			$expected_type = $registered_keys[ $meta_key ]['type'];
-			
+
 			// Fix the typing for numbers.
 			if ( 'number' === $expected_type ) {
 				$expected_type = 'integer';
 			}
 
 			$actual_type = gettype( $default_value );
-			
+
 			$this->assertSame(
 				$expected_type,
 				$actual_type,

--- a/wp-modules/editor/tests/UtilsTest.php
+++ b/wp-modules/editor/tests/UtilsTest.php
@@ -19,7 +19,7 @@ class UtilsTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function tearDown() {
+	public function tearDown() : void {
 		delete_pattern_posts();
 		parent::tearDown();
 	}

--- a/wp-modules/get-module-data/tests/PatternManagerGetModuleDataTest.php
+++ b/wp-modules/get-module-data/tests/PatternManagerGetModuleDataTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class GetModuleDataTest
+ * Class PatternManagerGetModuleDataTest
  *
  * @package pattern-manager
  */

--- a/wp-modules/get-version-control/tests/GetVersionControlTest.php
+++ b/wp-modules/get-version-control/tests/GetVersionControlTest.php
@@ -20,7 +20,7 @@ class GetVersionControlTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	public function setUp() : void {
 		parent::setUp();
 
 		$this->user_id = $this->factory->user->create();
@@ -33,7 +33,7 @@ class GetVersionControlTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function tearDown() {
+	public function tearDown() : void {
 		delete_user_meta( $this->user_id, get_version_control_meta_key() );
 		wp_delete_user( $this->user_id );
 

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -20,7 +20,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	public function setUp() : void {
 		parent::setUp();
 		add_filter( 'request_filesystem_credentials', '__return_true' );
 		add_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );
@@ -30,7 +30,7 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function tearDown() {
+	public function tearDown() : void {
 		remove_filter( 'request_filesystem_credentials', '__return_true' );
 		remove_filter( 'stylesheet_directory', [ $this, 'get_fixtures_directory' ] );
 		remove_filter( 'stylesheet_directory_uri', [ $this, 'get_stylesheet_directory_uri' ] );


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
In the wp-env project (inside Gutenberg repo), the [PHPUnit and Composer packages were removed](https://github.com/WordPress/gutenberg/pull/50408). 

This resulted in PHPunit tests failing to run using wpp-scripts with the message:
`The 'phpunit' container has been removed. Please use 'wp-env run tests-cli --env-cwd=wp-content/path/to/plugin phpunit' instead.`

In fixing it, I was getting this error:
`PHP Fatal error:  Declaration of PatternManager\PatternDataHandlers\PatternDataHandlersTest::setUp() must be compatible with Yoast\PHPUnitPolyfills\TestCases\TestCase::setUp(): void in /var/www/html/wp-content/plugins/pattern-manager/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php on line 23
`

The fix is to make sure that setUp and tearDown declarations have a void declared for their return type.

I was also seeing errors for `Array to string conversion` on `test_register_pattern_post_type_meta_types`. This is apparently the error message you get if you use `array_diff` [but one of them is multi-dimentional.](https://stackoverflow.com/questions/19830585/array-to-string-conversion-error-when-calling-array-diff-assoc-with-a-multid)

### How to test
1. Make sure tests pass on circleci, or run them locally with `npm run test:phpunit`
