### PR TITLE
Chang the 'Replace' button to 'Replace Pattern'

### DIFF
--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -109,7 +109,7 @@ export default function PatternEdit( {
 					<PatternInspector pattern={ pattern } />
 					<BlockControls group="block">
 						<Button onClick={ () => setModalOpen( true ) }>
-							{ __( 'Replace', 'pattern-manager' ) }
+							{ __( 'Replace Pattern', 'pattern-manager' ) }
 						</Button>
 					</BlockControls>
 					<div


### PR DESCRIPTION
### Summary of changes
Thanks to Kam for this idea.

Change the 'Replace' button to 'Replace Pattern'

### Before

<img width="1074" alt="Screenshot 2023-05-25 at 12 24 33 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/61c241d9-59ed-4e18-84c0-9e26b7ede974">

### After

<img width="1071" alt="Screenshot 2023-05-25 at 11 44 06 AM" src="https://github.com/studiopress/pattern-manager/assets/4063887/451f945d-dd53-47ba-8d64-29bef486eb11">

### Related Issues
Fixes [GF-3804](https://wpengine.atlassian.net/browse/GF-3804)
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Create a new pattern
2. Add a Pattern Block
3. Select a pattern
4. Expected: The button says 'Replace Pattern':

<img width="1071" alt="Screenshot 2023-05-25 at 11 44 06 AM" src="https://github.com/studiopress/pattern-manager/assets/4063887/5105c2f9-a099-496a-a5c1-7ba7f967e4b0">


