### PR TITLE
Update the Patternception Inspector copy

### DIFF
--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -45,13 +45,13 @@ function PatternInspector( { pattern }: PatternInspectorProps ) {
 				>
 					<p>
 						{ __(
-							'This pattern is being used within the PM Pattern Block in order to create a multi-pattern layout.',
+							'This pattern is being used within the Pattern Manager Pattern Block in order to create a multi-pattern layout.',
 							'pattern-manager'
 						) }
 					</p>
 					<p>
 						{ __(
-							'Editing this pattern will change it across all instances of this pattern being used in PM Pattern Blocks.',
+							'Editing this pattern will update it within all Pattern Manager Pattern Blocks that use it.',
 							'pattern-manager'
 						) }
 					</p>

--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -43,10 +43,18 @@ function PatternInspector( { pattern }: PatternInspectorProps ) {
 					title={ __( 'Pattern', 'pattern-manager' ) }
 					initialOpen={ true }
 				>
-					{ __(
-						'This is a pattern placeholder, used for building layouts with pattern tags. To edit the pattern, click the button below.',
-						'pattern-manager'
-					) }
+					<p>
+						{ __(
+							'This pattern is being used within the PM Pattern Block in order to create a multi-pattern layout.',
+							'pattern-manager'
+						) }
+					</p>
+					<p>
+						{ __(
+							'Editing this pattern will change it across all instances of this pattern being used in PM Pattern Blocks.',
+							'pattern-manager'
+						) }
+					</p>
 					{ pattern ? (
 						<a
 							className="components-button is-secondary"


### PR DESCRIPTION
### Summary of changes
Mainly pastes Kam's copy into the Patternception Inspector copy

### Before

<img width="454" alt="Screenshot 2023-05-25 at 12 14 40 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/c01af564-ec95-425a-87b8-708a3dd12f91">

### After

<img width="517" alt="Screenshot 2023-05-25 at 12 06 35 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/736177f7-e9b8-41b5-a963-e01954370d07">

Copy Kam suggested in [GF-3803](https://wpengine.atlassian.net/browse/GF-3803):

>This pattern is being used within the PM Pattern Block in order to create a multi-pattern layout. To edit this pattern, click the button below. Note: Editing this pattern will change it across all instances of this pattern being used in the PM Pattern Block. 

Copy in this PR:

>This pattern is being used within the PM Pattern Block in order to create a multi-pattern layout. Editing this pattern will change it across all instances of this pattern being used in PM Pattern Blocks.

If it's alright, I removed 'To edit this pattern, click the button below.'

There's a lot of copy, and that doesn't add much.


### Related Issues
Fixes [GF-3803](https://wpengine.atlassian.net/browse/GF-3803)
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Create a new pattern
2. Add a Pattern Block
3. Select a pattern
4. Look at the inspector:

<img width="517" alt="Screenshot 2023-05-25 at 12 06 35 PM" src="https://github.com/studiopress/pattern-manager/assets/4063887/8467d6ea-1c1c-4a1e-ae85-83f5287c8f11">

