### PR TITLE
Add some files to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -9,6 +9,8 @@ js/src
 tests
 package.json
 package-lock.json
+.nvmrc
+webpack.config.js
 tsconfig.json
 .circleci
 .github


### PR DESCRIPTION
### Summary of changes
* Add `.nvmrc` and `webpack.config.js` to `.distignore`, so CCI doesn't deploy them to the wp.org SVN repo, and they're not in the `.zip` file

### How to test
* Download the `.zip` file from the CCI zip job's artifacts
* Unzip it
* Expected: There's no `wp-modules/editor/webpack.config.js`

