### PR TITLE
Add link to helper article in version control notice

### DIFF
--- a/wp-modules/app/js/src/components/VersionControlNotice/index.tsx
+++ b/wp-modules/app/js/src/components/VersionControlNotice/index.tsx
@@ -34,6 +34,7 @@ export default function VersionControlNotice( {
 							}
 							target="_blank"
 							rel="noopener noreferrer"
+							aria-label="Link to our Git Guide (opens in new tab)"
 						>
 							{ __( 'our Git Guide', 'pattern-manager' ) }
 						</a>


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->

This PR adds a link to a new [helper article](https://developer.wpengine.com/knowledge-base/using-git-with-a-wordpress-theme/) about setting up version control for a WordPress theme.

### Related Issues
<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Switch to a theme that has not had the version control notice dismissed (or delete the`patternmanager_version_control_notice_dismissed_themes` DB entry from usermeta)
2. Confirm that a link is displayed in the version control notice
3. Confirm that the link works

### Notes & Screenshots
<!-- Additional information for reviewers. -->

![Screenshot 2023-06-02 at 9 33 15 AM](https://github.com/studiopress/pattern-manager/assets/108079556/b60f6638-e216-4bc4-a208-f658b98a5c0f)
