### PR TITLE
Add tooltip to lock

### DIFF
--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -9,6 +9,7 @@ import {
 	Panel,
 	PanelBody,
 	Placeholder,
+	Tooltip,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { Icon, image, lock } from '@wordpress/icons';
@@ -120,34 +121,36 @@ export default function PatternEdit( {
 							{ __( 'Replace Pattern', 'pattern-manager' ) }
 						</Button>
 					</BlockControls>
-					<div
-						style={ {
-							right: '10px',
-							top: '10px',
-							position: 'absolute',
-							height: '35px',
-							width: '35px',
-							background: '#fff',
-							zIndex: '20',
-							borderRadius: '500px',
-							display: 'flex',
-							gap: '10px',
-							alignItems: 'center',
-							fontFamily:
-								'-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
-							fontSize: '16px',
-							padding: '5px',
-							border: 'solid 1px rgba(0,0,0,.1)',
-							boxSizing: 'border-box',
-						} }
-					>
-						<Icon
-							icon={ lock }
+					<Tooltip text="Patterns shown within the Pattern Block are locked.">
+						<div
 							style={ {
-								width: '25px',
+								right: '10px',
+								top: '10px',
+								position: 'absolute',
+								height: '35px',
+								width: '35px',
+								background: '#fff',
+								zIndex: '20',
+								borderRadius: '500px',
+								display: 'flex',
+								gap: '10px',
+								alignItems: 'center',
+								fontFamily:
+									'-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+								fontSize: '16px',
+								padding: '5px',
+								border: 'solid 1px rgba(0,0,0,.1)',
+								boxSizing: 'border-box',
 							} }
-						/>
-					</div>
+						>
+							<Icon
+								icon={ lock }
+								style={ {
+									width: '25px',
+								} }
+							/>
+						</div>
+					</Tooltip>
 					<ServerSideRender
 						block="core/pattern"
 						className="pm-pattern-container"


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->
Adds a tooltip to the lock icon.

### Related Issues
See [GF-3802](https://wpengine.atlassian.net/browse/GF-3802)

### How to test
<!-- Detailed steps to test this PR. -->
1. Hover on the lock icon when viewing a pattern inside the Pattern Block.

### Notes & Screenshots
<!-- Additional information for reviewers. -->
<img width="364" alt="Screenshot 2023-06-02 at 8 53 40 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/63e7ab63-03f2-459a-91df-5d8f642265f6">

We may still want to change the icon in the future.


