### PR TITLE
Don't tree shake in `delete_pattern()`

### DIFF
--- a/wp-modules/api-data/api-data.php
+++ b/wp-modules/api-data/api-data.php
@@ -15,6 +15,8 @@ use WP_REST_Request;
 use WP_REST_Response;
 use function \PatternManager\GetVersionControl\get_dismissed_themes;
 use function \PatternManager\GetVersionControl\get_version_control_meta_key;
+use function \PatternManager\GetWpFilesystem\get_wp_filesystem_api;
+use function PatternManager\PatternDataHandlers\tree_shake_theme_images;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -108,6 +110,7 @@ function get_pattern_names() {
  */
 function delete_pattern( $request ) {
 	$is_success = \PatternManager\PatternDataHandlers\delete_pattern( $request->get_params()['patternName'] );
+	tree_shake_theme_images( get_wp_filesystem_api(), 'copy_dir' );
 
 	return $is_success
 		? new WP_REST_Response(

--- a/wp-modules/app/js/src/components/VersionControlNotice/index.tsx
+++ b/wp-modules/app/js/src/components/VersionControlNotice/index.tsx
@@ -29,8 +29,6 @@ export default function VersionControlNotice( {
 					div: <div style={ { marginTop: '1rem' } }></div>,
 					a: (
 						<a
-							target="_blank"
-							rel="noreferrer"
 							href={
 								'https://developer.wpengine.com/knowledge-base/using-git-with-a-wordpress-theme/'
 							}

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -323,10 +323,7 @@ function update_pattern( $pattern ) {
 function delete_pattern( string $pattern_name ): bool {
 	$wp_filesystem = \PatternManager\GetWpFilesystem\get_wp_filesystem_api();
 	$pattern_path  = get_pattern_path( $pattern_name );
-	$result        = $wp_filesystem && $wp_filesystem->exists( $pattern_path ) && $wp_filesystem->delete( $pattern_path );
-	tree_shake_theme_images( $wp_filesystem, 'copy_dir' );
-
-	return $result;
+	return $wp_filesystem && $wp_filesystem->exists( $pattern_path ) && $wp_filesystem->delete( $pattern_path );
 }
 
 /**


### PR DESCRIPTION
### Summary of changes
A much simpler [subset](https://github.com/studiopress/pattern-manager/pull/192/files#r1227497186) of my bloated  https://github.com/studiopress/pattern-manager/pull/192 😄 

Maybe we'll consider https://github.com/studiopress/pattern-manager/pull/192, but if this PR doesn't work, I'll have to rework that.

### How to test
<!-- Detailed steps to test this PR. -->
Phil's [testing steps](https://github.com/studiopress/pattern-manager/pull/192#issue-1744354622)

I couldn't reproduce it, so this PR might not fix it.
