### PR TITLE
Add pattern title to the Pattern Block sidebar panel heading

### DIFF
--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -41,7 +41,11 @@ function PatternInspector( { pattern }: PatternInspectorProps ) {
 		<InspectorControls>
 			<Panel>
 				<PanelBody
-					title={ __( 'Pattern', 'pattern-manager' ) }
+					title={
+						pattern
+							? pattern.title
+							: __( 'Pattern', 'pattern-manager' )
+					}
 					initialOpen={ true }
 				>
 					<p>


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->
Adds the pattern title to the Pattern Block sidebar panel.

### Related Issues
Fixes https://wpengine.atlassian.net/browse/GF-3805

### How to test
<!-- Detailed steps to test this PR. -->
1. Add a Pattern Block in the pattern editor.
2. View the information presented in the sidebar. It should show `Pattern` when no pattern is selected yet. Once a pattern is selected, it will display the pattern title.

### Notes & Screenshots
<!-- Additional information for reviewers. -->

### Before:

<img width="279" alt="Screenshot 2023-06-15 at 12 09 13 PM" src="https://github.com/studiopress/pattern-manager/assets/1271053/4217fe3f-cb1d-4a43-ae20-1f338f209ca7">

### After:

<img width="282" alt="Screenshot 2023-06-15 at 11 41 02 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/5ec98fa6-afb9-4a51-91de-ae99a84a45a1">


