### PR TITLE
Validate new categories on input

### DIFF
--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -58,16 +58,16 @@ export default function CategoriesPanel( {
 						} );
 					} }
 					onCreateOption={ ( newCategoryTitle ) => {
+						const validatedTitle =
+							stripIllegalChars( newCategoryTitle );
+
 						handleChange(
 							'customCategories',
-							[
-								...customCategories,
-								stripIllegalChars( newCategoryTitle ),
-							],
+							[ ...customCategories, validatedTitle ],
 							{
 								categories: [
 									...categories,
-									toKebabCase( newCategoryTitle ),
+									toKebabCase( validatedTitle ),
 								],
 							}
 						);

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { Spinner } from '@wordpress/components';
 
@@ -7,6 +8,10 @@ import Creatable from 'react-select/creatable';
 import toKebabCase from '../../utils/toKebabCase';
 import getSelectedOptions from '../../utils/getSelectedOptions';
 import getCustomCategories from '../../utils/getCustomCategories';
+import {
+	checkIllegalChars,
+	stripIllegalChars,
+} from '../../utils/validateInput';
 import type { BaseSidebarProps, AdditionalSidebarProps } from './types';
 
 /**
@@ -20,6 +25,9 @@ export default function CategoriesPanel( {
 	handleChange,
 }: BaseSidebarProps< 'categories' | 'customCategories' > &
 	AdditionalSidebarProps< 'categoryOptions' > ) {
+	const [ categoryTitleIsInvalid, setCategoryTitleIsInvalid ] =
+		useState( false );
+
 	return (
 		<PluginDocumentSettingPanel
 			name="patternmanager-pattern-editor-pattern-categories"
@@ -55,7 +63,10 @@ export default function CategoriesPanel( {
 					onCreateOption={ ( newCategoryTitle ) => {
 						handleChange(
 							'customCategories',
-							[ ...customCategories, newCategoryTitle ],
+							[
+								...customCategories,
+								stripIllegalChars( newCategoryTitle ),
+							],
 							{
 								categories: [
 									...categories,
@@ -64,11 +75,25 @@ export default function CategoriesPanel( {
 							}
 						);
 					} }
+					onInputChange={ ( event ) => {
+						setCategoryTitleIsInvalid(
+							!! checkIllegalChars( event )
+						);
+					} }
 					menuPlacement="auto"
 					styles={ {
 						menu: ( base ) => ( {
 							...base,
 							zIndex: 100,
+						} ),
+						control: ( baseStyles ) => ( {
+							...baseStyles,
+							borderColor: categoryTitleIsInvalid
+								? 'red !important'
+								: baseStyles.borderColor,
+							boxShadow: categoryTitleIsInvalid
+								? '0 0 0 1px red'
+								: baseStyles.boxShadow,
 						} ),
 					} }
 				/>

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -8,10 +8,7 @@ import Creatable from 'react-select/creatable';
 import toKebabCase from '../../utils/toKebabCase';
 import getSelectedOptions from '../../utils/getSelectedOptions';
 import getCustomCategories from '../../utils/getCustomCategories';
-import {
-	checkIllegalChars,
-	stripIllegalChars,
-} from '../../utils/validateInput';
+import { hasIllegalChars, stripIllegalChars } from '../../utils/validateInput';
 import type { BaseSidebarProps, AdditionalSidebarProps } from './types';
 
 /**
@@ -76,9 +73,7 @@ export default function CategoriesPanel( {
 						);
 					} }
 					onInputChange={ ( event ) => {
-						setCategoryTitleIsInvalid(
-							!! checkIllegalChars( event )
-						);
+						setCategoryTitleIsInvalid( hasIllegalChars( event ) );
 					} }
 					formatCreateLabel={ ( userInput ) =>
 						`Create "${ stripIllegalChars( userInput ) }"`

--- a/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/CategoriesPanel.tsx
@@ -80,6 +80,9 @@ export default function CategoriesPanel( {
 							!! checkIllegalChars( event )
 						);
 					} }
+					formatCreateLabel={ ( userInput ) =>
+						`Create "${ stripIllegalChars( userInput ) }"`
+					}
 					menuPlacement="auto"
 					styles={ {
 						menu: ( base ) => ( {

--- a/wp-modules/editor/js/src/utils/test/validateInput.ts
+++ b/wp-modules/editor/js/src/utils/test/validateInput.ts
@@ -3,7 +3,7 @@ import { hasIllegalChars, stripIllegalChars } from '../validateInput';
 const regexPattern = new RegExp( /([^a-z0-9 -]+)/gi );
 
 describe( 'validateInput', () => {
-	describe( 'checkIllegalChars', () => {
+	describe( 'hasIllegalChars', () => {
 		it.each( [
 			[ '', false ],
 			[ 'Nothing to strip', false ],

--- a/wp-modules/editor/js/src/utils/test/validateInput.ts
+++ b/wp-modules/editor/js/src/utils/test/validateInput.ts
@@ -1,21 +1,16 @@
-import { checkIllegalChars, stripIllegalChars } from '../validateInput';
+import { hasIllegalChars, stripIllegalChars } from '../validateInput';
 
 const regexPattern = new RegExp( /([^a-z0-9 -]+)/gi );
 
 describe( 'validateInput', () => {
 	describe( 'checkIllegalChars', () => {
 		it.each( [
-			[ '', null ],
-			[ 'Nothing to strip', null ],
-			[ 'String with !#@$%^&*() illegal chars', [ '!#@$%^&*()' ] ],
-			[
-				'String !#@$% with ^&*() separated \'"? illegal []{}|/ chars',
-				[ '!#@$%', '^&*()', '\'"?', '[]{}|/' ],
-			],
+			[ '', false ],
+			[ 'Nothing to strip', false ],
+			[ "String that might've been a problem", true ],
+			[ 'String with !#@$% illegal ^&*() chars', true ],
 		] )( 'matches the illegal characters', ( input, expected ) => {
-			expect( checkIllegalChars( input, regexPattern ) ).toEqual(
-				expected
-			);
+			expect( hasIllegalChars( input, regexPattern ) ).toBe( expected );
 		} );
 	} );
 	describe( 'stripIllegalChars', () => {

--- a/wp-modules/editor/js/src/utils/test/validateInput.ts
+++ b/wp-modules/editor/js/src/utils/test/validateInput.ts
@@ -1,0 +1,37 @@
+import { checkIllegalChars, stripIllegalChars } from '../validateInput';
+
+const regexPattern = new RegExp( /([^a-z0-9 -]+)/gi );
+
+describe( 'validateInput', () => {
+	describe( 'checkIllegalChars', () => {
+		it.each( [
+			[ '', null ],
+			[ 'Nothing to strip', null ],
+			[ 'String with !#@$%^&*() illegal chars', [ '!#@$%^&*()' ] ],
+			[
+				'String !#@$% with ^&*() separated \'"? illegal []{}|/ chars',
+				[ '!#@$%', '^&*()', '\'"?', '[]{}|/' ],
+			],
+		] )( 'matches the illegal characters', ( input, expected ) => {
+			expect( checkIllegalChars( input, regexPattern ) ).toEqual(
+				expected
+			);
+		} );
+	} );
+	describe( 'stripIllegalChars', () => {
+		it.each( [
+			[ '', '' ],
+			[ 'Nothing to strip', 'Nothing to strip' ],
+			[
+				'String with !#@$%^&*() illegal chars',
+				'String with  illegal chars',
+			],
+			[
+				"This might've caused a whitescreen previously!",
+				'This mightve caused a whitescreen previously',
+			],
+		] )( 'strips the illegal characters', ( input, expected ) => {
+			expect( stripIllegalChars( input, regexPattern ) ).toBe( expected );
+		} );
+	} );
+} );

--- a/wp-modules/editor/js/src/utils/validateInput.ts
+++ b/wp-modules/editor/js/src/utils/validateInput.ts
@@ -1,10 +1,10 @@
 const defaultPattern = new RegExp( /([^a-z0-9 -]+)/gi );
 
-export function checkIllegalChars(
+export function hasIllegalChars(
 	input: string,
 	regexPattern = defaultPattern
 ) {
-	return input.match( regexPattern );
+	return !! input.match( regexPattern );
 }
 
 export function stripIllegalChars(

--- a/wp-modules/editor/js/src/utils/validateInput.ts
+++ b/wp-modules/editor/js/src/utils/validateInput.ts
@@ -1,0 +1,15 @@
+const defaultPattern = new RegExp( /([^a-z0-9 -]+)/gi );
+
+export function checkIllegalChars(
+	input: string,
+	regexPattern = defaultPattern
+) {
+	return input.match( regexPattern );
+}
+
+export function stripIllegalChars(
+	input: string,
+	regexPattern = defaultPattern
+) {
+	return input.replace( regexPattern, '' );
+}


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->

Previously, typing certain characters could cause issues (up to a whitescreen) when new categories were created in the sidebar UI. This PR adds strict validation as the user types, then strips disallowed characters on `Enter`.

### Related Issues
<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Open or create a pattern
2. Try adding a category with non-alphanumeric characters
3. Expected: the disallowed characters should be stripped on `Enter`

### Notes & Screenshots
<!-- Additional information for reviewers. -->

A hint is provided by a red border that only appears when disallowed chars are detected. Additionally, the `Create ""` label shown below the input as the new category title is typed has the disallowed characters stripped:

![Screenshot 2023-06-15 at 2 24 14 PM](https://github.com/studiopress/pattern-manager/assets/108079556/e41f30fe-6a3f-466d-b10b-8d6ac6ba4bd9)