### PR TITLE
Update icon, conditionally display sidebar text

### DIFF
--- a/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
+++ b/wp-modules/editor/js/src/blocks/pattern-block/PatternEdit.tsx
@@ -12,7 +12,7 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { Icon, image, lock } from '@wordpress/icons';
+import { Icon, layout, lock } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 import { patternManager } from '../../globals';
@@ -48,25 +48,36 @@ function PatternInspector( { pattern }: PatternInspectorProps ) {
 					}
 					initialOpen={ true }
 				>
-					<p>
-						{ __(
-							'This pattern is being used within the Pattern Manager Pattern Block in order to create a multi-pattern layout.',
-							'pattern-manager'
-						) }
-					</p>
-					<p>
-						{ __(
-							'Editing this pattern will update it within all Pattern Manager Pattern Blocks that use it.',
-							'pattern-manager'
-						) }
-					</p>
+					{ pattern ? (
+						<>
+							<p>
+								{ __(
+									'This pattern is being used within the Pattern Manager Pattern Block to create a multi-pattern layout.',
+									'pattern-manager'
+								) }
+							</p>
+							<p>
+								{ __(
+									'Editing this pattern will update it within all Pattern Manager Pattern Blocks that use it.',
+									'pattern-manager'
+								) }
+							</p>
+						</>
+					) : (
+						<p>
+							{ __(
+								'Select a pattern to display in the Pattern Block.',
+								'pattern-manager'
+							) }
+						</p>
+					) }
 					{ pattern ? (
 						<a
 							className="components-button is-secondary"
 							style={ { marginTop: '10px' } }
 							href={ pattern.editorLink }
 						>
-							{ __( 'Edit This Pattern', 'pattern-manager' ) }
+							{ __( 'Edit this Pattern', 'pattern-manager' ) }
 						</a>
 					) : null }
 				</PanelBody>
@@ -166,7 +177,7 @@ export default function PatternEdit( {
 				<div { ...blockProps }>
 					<PatternInspector />
 					<Placeholder
-						icon={ image }
+						icon={ layout }
 						label={ __( 'Pattern Block', 'pattern-manager' ) }
 						instructions={ __(
 							'Build a multi-pattern layout with more than one Pattern Block.',

--- a/wp-modules/editor/js/src/blocks/pattern-block/registerPatternBlock.ts
+++ b/wp-modules/editor/js/src/blocks/pattern-block/registerPatternBlock.ts
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import PatternEdit from './PatternEdit';
+import { layout } from '@wordpress/icons';
 
 export default function registerPatternBlock(
 	settings: Record< string, unknown >,
@@ -9,7 +10,7 @@ export default function registerPatternBlock(
 		? {
 				...settings,
 				title: __( 'Pattern Block', 'pattern-manager' ),
-				icon: 'text',
+				icon: layout,
 				category: 'common',
 				description: __(
 					'Build a multi-pattern layout with more than one Pattern Block.',


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
<!-- A short but detailed summary of the changes. -->

Updates the icon for the Pattern Block so it is the same in all areas. Also, updates the sidebar text used for the Pattern Block when no pattern is yet selected.

### Related Issues
<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Insert a Pattern Block.
2. Check that the icon is the same per the image below.
3. Check that the sidebar text directs to select a pattern when no pattern is selected.

### Notes & Screenshots
<!-- Additional information for reviewers. -->

Before:
<img width="1410" alt="Screenshot 2023-06-30 at 9 03 09 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/af87144e-8091-4e59-9e9a-41faad7d1958">

After:
<img width="1411" alt="Screenshot 2023-06-30 at 8 46 53 AM" src="https://github.com/studiopress/pattern-manager/assets/1271053/e68deebc-8062-4ea7-b3e3-584a0c349507">

