### PR TITLE
Fix: Remove extra comma which is inserted for themes without a textdomain

### DIFF
--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -397,7 +397,7 @@ function create_formatted_category_registrations( $custom_categories ) {
 			function ( $category_label ) {
 				$category_name = strtolower( str_replace( ' ', '-', $category_label ) );
 				$text_domain   = wp_get_theme()->get( 'TextDomain' );
-				$label_arr     = $text_domain ? "[ 'label' => __( '$category_label', '$text_domain' ), 'pm_custom' => true ]" : "[ 'label' => '$category_label', , 'pm_custom' => true ]";
+				$label_arr     = $text_domain ? "[ 'label' => __( '$category_label', '$text_domain' ), 'pm_custom' => true ]" : "[ 'label' => '$category_label', 'pm_custom' => true ]";
 				return "register_block_pattern_category( '$category_name', $label_arr );";
 			},
 			$custom_categories,

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -109,9 +109,9 @@ class PatternDataHandlersTest extends WP_UnitTestCase {
 	 */
 	public function get_expected_custom_category_registrations() {
 		return "
-register_block_pattern_category( 'first-custom', [ 'label' => 'First Custom', , 'pm_custom' => true ] );
-register_block_pattern_category( 'second-custom', [ 'label' => 'Second Custom', , 'pm_custom' => true ] );
-register_block_pattern_category( 'third-custom', [ 'label' => 'Third Custom', , 'pm_custom' => true ] );";
+register_block_pattern_category( 'first-custom', [ 'label' => 'First Custom', 'pm_custom' => true ] );
+register_block_pattern_category( 'second-custom', [ 'label' => 'Second Custom', 'pm_custom' => true ] );
+register_block_pattern_category( 'third-custom', [ 'label' => 'Third Custom', 'pm_custom' => true ] );";
 	}
 
 	/**


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
If a theme doesn't have a TextDomain, patterns that have custom categories will have an extra comma in the PHP code, causing a fatal error.

### How to test
1. Make a theme but have no `TextDomain` in the style.css file
2. Make a pattern with PM and add a custom category to it, and save the pattern.
3. The site should not fatal.

Related: 
https://wordpress.org/support/topic/creating-custom-category-causes-fatal-error/#post-16961268