### PR TITLE
Add a nonce to duplicate and edit actions

### DIFF
--- a/wp-modules/app/app.php
+++ b/wp-modules/app/app.php
@@ -27,6 +27,7 @@ function get_app_state() {
 		'patterns'                 => \PatternManager\PatternDataHandlers\get_theme_patterns_with_editor_links(),
 		'patternCategories'        => \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		'apiNonce'                 => wp_create_nonce( 'wp_rest' ),
+		'previewNonce'             => wp_create_nonce( 'pm_action_pattern_preview' ),
 		'apiEndpoints'             => array(
 			'deletePatternEndpoint'         => get_rest_url( false, 'pattern-manager/v1/delete-pattern/' ),
 			'updateDismissedSitesEndpoint'  => get_rest_url( false, 'pattern-manager/v1/update-dismissed-sites/' ),

--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -59,11 +59,7 @@ export default function PatternGrid( {
 									<div className="item-pattern-preview">
 										<PatternPreview
 											key={ patternName }
-											url={
-												siteUrl +
-												'?pm_pattern_preview=' +
-												patternData.name
-											}
+											url={ patternData.previewLink }
 											viewportWidth={
 												patternData.viewportWidth ||
 												1280

--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -59,7 +59,11 @@ export default function PatternGrid( {
 									<div className="item-pattern-preview">
 										<PatternPreview
 											key={ patternName }
-											url={ patternData.previewLink }
+											url={
+												siteUrl +
+												'?pm_pattern_preview=' +
+												patternData.name
+											}
 											viewportWidth={
 												patternData.viewportWidth ||
 												1280

--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -59,11 +59,7 @@ export default function PatternGrid( {
 									<div className="item-pattern-preview">
 										<PatternPreview
 											key={ patternName }
-											url={
-												siteUrl +
-												'?pm_pattern_preview=' +
-												patternData.name
-											}
+											url={ `${ siteUrl }?pm_pattern_preview=${ patternData.name }&_wpnonce=${ patternManager.previewNonce }` }
 											viewportWidth={
 												patternData.viewportWidth ||
 												1280

--- a/wp-modules/app/js/src/components/Patterns/PatternGridActions.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGridActions.tsx
@@ -46,7 +46,7 @@ export default function PatternGridActions( { patternData }: Props ) {
 						__( 'Duplicate %1$s', 'pattern-manager' ),
 						patternData.title
 					) }
-					href={ `${ patternManager.siteUrl }/wp-admin/admin.php?post_type=pm_pattern&action=duplicate&name=${ patternData.name }` }
+					href={ patternData.duplicateLink }
 				>
 					<Icon
 						className="item-action-icon"

--- a/wp-modules/app/js/src/types.ts
+++ b/wp-modules/app/js/src/types.ts
@@ -26,7 +26,6 @@ export type Pattern = {
 	content: string;
 	duplicateLink: string;
 	editorLink: string;
-	previewLink: string;
 	name: string;
 	slug: string;
 	title: string;

--- a/wp-modules/app/js/src/types.ts
+++ b/wp-modules/app/js/src/types.ts
@@ -26,6 +26,7 @@ export type Pattern = {
 	content: string;
 	duplicateLink: string;
 	editorLink: string;
+	previewLink: string;
 	name: string;
 	slug: string;
 	title: string;

--- a/wp-modules/app/js/src/types.ts
+++ b/wp-modules/app/js/src/types.ts
@@ -15,6 +15,7 @@ export type InitialPatternManager = {
 		updateDismissedThemesEndpoint: string;
 	};
 	apiNonce: string;
+	previewNonce: string;
 	patternCategories: QueriedCategories;
 	patterns: Patterns;
 	siteUrl: string;

--- a/wp-modules/app/js/src/types.ts
+++ b/wp-modules/app/js/src/types.ts
@@ -24,6 +24,7 @@ export type InitialPatternManager = {
 
 export type Pattern = {
 	content: string;
+	duplicateLink: string;
 	editorLink: string;
 	name: string;
 	slug: string;

--- a/wp-modules/app/tests/AppTest.php
+++ b/wp-modules/app/tests/AppTest.php
@@ -25,6 +25,7 @@ class AppTest extends WP_UnitTestCase {
 				'patterns',
 				'patternCategories',
 				'apiNonce',
+				'previewNonce',
 				'apiEndpoints',
 				'siteUrl',
 				'adminUrl',

--- a/wp-modules/editor/editor.php
+++ b/wp-modules/editor/editor.php
@@ -239,6 +239,7 @@ function enqueue_meta_fields_in_editor() {
 				'getPatternNamesEndpoint' => get_rest_url( false, 'pattern-manager/v1/get-pattern-names/' ),
 			),
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
+			'previewNonce'      => wp_create_nonce( 'pm_action_pattern_preview' ),
 			'patternCategories' => \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 			'patternNames'      => get_pattern_names(),
 			'patterns'          => \PatternManager\PatternDataHandlers\get_theme_patterns_with_editor_links(),

--- a/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
+++ b/wp-modules/editor/js/src/components/SidebarPanels/ViewportWidthPanel.tsx
@@ -51,11 +51,7 @@ export default function ViewportWidthPanel( {
 					/>
 				) : (
 					<PatternPreview
-						url={
-							patternManager.siteUrl +
-							'?pm_pattern_preview=' +
-							currentName
-						}
+						url={ `${ patternManager.siteUrl }?pm_pattern_preview=${ currentName }&_wpnonce=${ patternManager.previewNonce }` }
 						viewportWidth={ currentWidth }
 					/>
 				) ) }

--- a/wp-modules/editor/js/src/types.ts
+++ b/wp-modules/editor/js/src/types.ts
@@ -58,6 +58,7 @@ export type Patterns = {
 export type InitialPatternManager = {
 	activeTheme: string;
 	apiNonce: string;
+	previewNonce: string;
 	apiEndpoints: {
 		getPatternNamesEndpoint: string;
 	};

--- a/wp-modules/editor/model.php
+++ b/wp-modules/editor/model.php
@@ -188,10 +188,12 @@ function redirect_pattern_actions() {
 	}
 
 	if ( 'duplicate' === filter_input( INPUT_GET, 'action' ) ) {
+		check_admin_referer( 'pm-pattern-duplicate' );
 		duplicate_pattern( filter_input( INPUT_GET, 'name' ) );
 	}
 
 	if ( 'edit-pattern' === filter_input( INPUT_GET, 'action' ) ) {
+		check_admin_referer( 'pm-pattern-edit' );
 		edit_pattern( filter_input( INPUT_GET, 'name' ) );
 	}
 }

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -168,6 +168,7 @@ function get_theme_patterns_with_editor_links() {
 
 			$duplicate_nonce_action = 'pm-pattern-duplicate';
 			$edit_nonce_action      = 'pm-pattern-edit';
+			$preview_nonce_action   = 'pm-pattern-preview';
 			$new_pattern            = array_merge(
 				$pattern,
 				[
@@ -192,6 +193,13 @@ function get_theme_patterns_with_editor_links() {
 							'_wpnonce'  => wp_create_nonce( $duplicate_nonce_action ),
 						],
 						admin_url()
+					),
+					'previewLink'   => add_query_arg(
+						[
+							'pm_preview_pattern_name' => $pattern['name'],
+							'_wpnonce'                => wp_create_nonce( $preview_nonce_action ),
+						],
+						get_bloginfo( 'url' )
 					),
 				]
 			);

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -168,7 +168,6 @@ function get_theme_patterns_with_editor_links() {
 
 			$duplicate_nonce_action = 'pm-pattern-duplicate';
 			$edit_nonce_action      = 'pm-pattern-edit';
-			$preview_nonce_action   = 'pm-pattern-preview';
 			$new_pattern            = array_merge(
 				$pattern,
 				[
@@ -193,13 +192,6 @@ function get_theme_patterns_with_editor_links() {
 							'_wpnonce'  => wp_create_nonce( $duplicate_nonce_action ),
 						],
 						admin_url()
-					),
-					'previewLink'   => add_query_arg(
-						[
-							'pm_preview_pattern_name' => $pattern['name'],
-							'_wpnonce'                => wp_create_nonce( $preview_nonce_action ),
-						],
-						get_bloginfo( 'url' )
 					),
 				]
 			);

--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -166,18 +166,37 @@ function get_theme_patterns_with_editor_links() {
 			);
 			$post  = empty( $query->posts[0] ) ? false : $query->posts[0];
 
-			$pattern['editorLink'] = $post && $post->name === $pattern['name']
-				? get_edit_post_link( $post, 'localized_data' )
-				: add_query_arg(
-					[
-						'post_type' => get_pattern_post_type(),
-						'action'    => 'edit-pattern',
-						'name'      => $pattern['name'],
-					],
-					admin_url()
-				);
+			$duplicate_nonce_action = 'pm-pattern-duplicate';
+			$edit_nonce_action      = 'pm-pattern-edit';
+			$new_pattern            = array_merge(
+				$pattern,
+				[
+					'editorLink'    => $post && $post->name === $pattern['name']
+						? add_query_arg(
+							[ '_wpnonce' => wp_create_nonce( $edit_nonce_action ) ],
+							get_edit_post_link( $post, 'localized_data' ),
+						)
+						: add_query_arg(
+							[
+								'post_type' => get_pattern_post_type(),
+								'action'    => 'edit-pattern',
+								'name'      => $pattern['name'],
+								'_wpnonce'  => wp_create_nonce( $edit_nonce_action ),
+							]
+						),
+					'duplicateLink' => add_query_arg(
+						[
+							'post_type' => get_pattern_post_type(),
+							'action'    => 'duplicate',
+							'name'      => $pattern['name'],
+							'_wpnonce'  => wp_create_nonce( $duplicate_nonce_action ),
+						],
+						admin_url()
+					),
+				]
+			);
 
-			$all_patterns[ $pattern_name ] = $pattern;
+			$all_patterns[ $pattern_name ] = $new_pattern;
 		}
 	}
 

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -252,6 +252,12 @@ register_block_pattern_category( 'third-custom', [ 'label' => 'Third Custom', 'p
 		$this->assertCount( 2, array_values( $patterns ) );
 		$this->assertTrue(
 			array_key_exists(
+				'duplicateLink',
+				$patterns['my-new-pattern']
+			)
+		);
+		$this->assertTrue(
+			array_key_exists(
 				'editorLink',
 				$patterns['my-new-pattern']
 			)

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -262,12 +262,6 @@ register_block_pattern_category( 'third-custom', [ 'label' => 'Third Custom', 'p
 				$patterns['my-new-pattern']
 			)
 		);
-		$this->assertTrue(
-			array_key_exists(
-				'previewLink',
-				$patterns['my-new-pattern']
-			)
-		);
 	}
 
 	/**

--- a/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
+++ b/wp-modules/pattern-data-handlers/tests/PatternDataHandlersTest.php
@@ -262,6 +262,12 @@ register_block_pattern_category( 'third-custom', [ 'label' => 'Third Custom', 'p
 				$patterns['my-new-pattern']
 			)
 		);
+		$this->assertTrue(
+			array_key_exists(
+				'previewLink',
+				$patterns['my-new-pattern']
+			)
+		);
 	}
 
 	/**

--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -20,13 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Receive pattern id in the URL and display its content. Useful for pattern previews and thumbnails.
  */
 function display_block_pattern_preview() {
-	if ( ! isset( $_GET['pm_preview_pattern_name'] ) ) {
+
+	// Nonce not required as the user is not taking any action here.
+	if ( ! isset( $_GET['pm_pattern_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return;
 	}
 
-	check_admin_referer( 'pm-pattern-preview' );
-
-	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_preview_pattern_name'] ) );
+	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_pattern_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	$pattern = \PatternManager\PatternDataHandlers\get_pattern_by_name( $pattern_name );
 

--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -20,15 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Receive pattern id in the URL and display its content. Useful for pattern previews and thumbnails.
  */
 function display_block_pattern_preview() {
-
-	// Nonce not required as the user is not taking any action here.
-	if ( ! isset( $_GET['pm_pattern_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( ! isset( $_GET['pm_pattern_preview'] ) ) {
 		return;
 	}
 
-	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_pattern_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	check_admin_referer( 'pm_action_pattern_preview' );
 
-	$pattern = \PatternManager\PatternDataHandlers\get_pattern_by_name( $pattern_name );
+	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_pattern_preview'] ) );
+	$pattern      = \PatternManager\PatternDataHandlers\get_pattern_by_name( $pattern_name );
 
 	if ( ! isset( $pattern['content'] ) ) {
 		$pattern['content'] = '';

--- a/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
+++ b/wp-modules/pattern-preview-renderer/pattern-preview-renderer.php
@@ -20,13 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Receive pattern id in the URL and display its content. Useful for pattern previews and thumbnails.
  */
 function display_block_pattern_preview() {
-
-	// Nonce not required as the user is not taking any action here.
-	if ( ! isset( $_GET['pm_pattern_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( ! isset( $_GET['pm_preview_pattern_name'] ) ) {
 		return;
 	}
 
-	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_pattern_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	check_admin_referer( 'pm-pattern-preview' );
+
+	$pattern_name = sanitize_text_field( wp_unslash( $_GET['pm_preview_pattern_name'] ) );
 
 	$pattern = \PatternManager\PatternDataHandlers\get_pattern_by_name( $pattern_name );
 


### PR DESCRIPTION
### Summary of changes
Adds a nonce when you edit or duplicate a pattern:

![Screenshot 2023-10-30 at 7 16 45 PM](https://github.com/studiopress/pattern-manager/assets/4063887/016066e8-c544-4ded-98f4-3eae50763c74)

Also adds a [nonce to pattern previews](https://github.com/studiopress/pattern-manager/pull/215/files#r1376979717). This is needless, but it could prevent an argument.

### Related Issues
<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Go to the Patterns page
2. Click 'Edit' and 'Duplicate'
3. Expected: Those go to the editor

![Screenshot 2023-10-30 at 7 16 45 PM](https://github.com/studiopress/pattern-manager/assets/4063887/fe607eb7-e597-4287-b5da-1177640f7d55)

