### PR TITLE
Add filters to allow pattern image directory customization

### DIFF
--- a/wp-modules/pattern-data-handlers/pattern-data-handlers.php
+++ b/wp-modules/pattern-data-handlers/pattern-data-handlers.php
@@ -570,12 +570,6 @@ function move_block_images_to_theme( $pattern_html ) {
 			FS_CHMOD_FILE
 		);
 
-		$file_saved_dist = $wp_filesystem->put_contents(
-			$wp_theme_dir . $images_folder_dist . $filename,
-			$file_contents,
-			FS_CHMOD_FILE
-		);
-
 		// Replace the URL with the one we just added to the theme.
 		$pattern_html = str_replace( $url_found, "<?php echo esc_url( get_stylesheet_directory_uri() ); ?>$images_folder_dist$filename", $pattern_html );
 	}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/studiopress/pattern-manager/wiki/For-Developers#contributor-license-agreement-cla) with WP Engine.

### Summary of changes
In this PR I have added the following filters to `wp-modules/pattern-data-handlers/pattern-data-handlers.php`:

`wpe_pattern_manager_pattern_images_dir` and `wpe_pattern_manager_pattern_images_dir_dist`

These filters allow theme authors to customize where pattern assets are stored in their theme, allowing them to better integrate with any build tools that they may be using.

### How to test
<!-- Detailed steps to test this PR. -->
1. Install and activate the plugin.
2. In your theme's `functions.php` file, add the following code:
```php
function custom_theme_assets_dir( $assets_dir ) {
	$assets_dir = '/assets/images/';
	return $assets_dir;
}
add_filter( 'wpe_pattern_manager_pattern_images_dir', 'custom_theme_assets_dir' );

function custom_theme_assets_dir_dist( $assets_dir ) {
	$assets_dir = '/dist/assets/images/';
	return $assets_dir;
}
add_filter( 'wpe_pattern_manager_pattern_images_dir_dist', 'custom_theme_assets_dir_dist' );
```
3. Customize the $assets_dir variables according to your theme's setup. The assumption here is that the `dist` directory will be automatically generated by the theme. If no `dist` directory is set using the filter, the plugin uses the directory set by `wpe_pattern_manager_pattern_images_dir` as the default.
4. Create and save a pattern with an image using the pattern manager plugin.
5. Observe that the image is created in directory specified by `wpe_pattern_manager_pattern_images_dir`.
6. Observe that the URL of the image in the pattern is set to the directory specified by `wpe_pattern_manager_pattern_images_dir_dist`.

### Notes & Screenshots
~~I have submitted the form to sign the CLA, but haven't gotten the email yet. I will update my PR once I have received and signed the CLA.~~
