### PR TITLE
Update to Pluginade 0.0.3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,38 @@
+{
+  "extends": [
+    "plugin:@wordpress/eslint-plugin/recommended"
+  ],
+  "globals": {
+    "beforeEach": "readonly",
+    "describe": "readonly",
+    "expect": "readonly",
+    "it": "readonly",
+    "jest": "readonly",
+    "test": "readonly"
+  },
+  "settings": {
+    "jsdoc": {
+      "mode": "typescript"
+    },
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    }
+  },
+  "rules": {
+    "react/jsx-no-target-blank": "off"
+  },
+  "overrides": [
+    {
+      "files": [ "*.ts", "*.tsx" ],
+      "rules": {
+        "jsdoc/require-param": "off",
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-returns-type": "off",
+        "no-unused-vars": "off",
+        "no-undef": "off"
+      }
+    }
+  ]
+}

--- a/pluginade.sh
+++ b/pluginade.sh
@@ -4,7 +4,7 @@
 
 # Set this to the version of pluginade-scripts you want to use.
 # For a list of available versions, see https://github.com/pluginade/pluginade-scripts/tags
-pluginadeversion="0.0.3-beta-7";
+pluginadeversion="0.0.3-beta-8";
 
 # Change the following variables to your plugin's namespace and textdomain:
 textdomain="pattern-manager";

--- a/pluginade.sh
+++ b/pluginade.sh
@@ -4,7 +4,7 @@
 
 # Set this to the version of pluginade-scripts you want to use.
 # For a list of available versions, see https://github.com/pluginade/pluginade-scripts/tags
-pluginadeversion="0.0.2";
+pluginadeversion="0.0.3-beta-7";
 
 # Change the following variables to your plugin's namespace and textdomain:
 textdomain="pattern-manager";

--- a/wp-modules/app/js/src/components/App/index.scss
+++ b/wp-modules/app/js/src/components/App/index.scss
@@ -140,7 +140,7 @@ html body.toplevel_page_pattern-manager {
 
 			.components-notice__content {
 				margin-right: 0;
-	
+
 				span {
 					margin-left: 2px;
 					text-decoration: none;

--- a/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
+++ b/wp-modules/app/js/src/components/Patterns/PatternGrid.tsx
@@ -31,7 +31,7 @@ export default function PatternGrid( {
 	patterns,
 	siteUrl,
 }: Props ) {
-	useForceRerender( [ patterns ] );
+	useForceRerender( patterns );
 
 	return (
 		<>

--- a/wp-modules/app/js/src/hooks/useForceRerender.ts
+++ b/wp-modules/app/js/src/hooks/useForceRerender.ts
@@ -11,7 +11,7 @@ export default function useForceRerender< T extends unknown >(
 
 	useLayoutEffect( () => {
 		setForceUpdate( [ window.innerWidth, window.innerHeight ] );
-		console.log( 'kjshgdkjhsdg' );
+
 		function updateSizeAndRerender() {
 			setForceUpdate( [ window.innerWidth, window.innerHeight ] );
 		}

--- a/wp-modules/app/js/src/hooks/useForceRerender.ts
+++ b/wp-modules/app/js/src/hooks/useForceRerender.ts
@@ -1,16 +1,17 @@
 import { useLayoutEffect, useState } from '@wordpress/element';
+import type { Patterns } from '../types';
 
 type WindowDimensions = [ number, number ];
 
 /** Re-render the calling component when the window is resized or dependencies update. */
 export default function useForceRerender< T extends unknown >(
-	dependencies: T[]
+	dependencies: Patterns
 ) {
 	const [ , setForceUpdate ] = useState< T[] | WindowDimensions >();
 
 	useLayoutEffect( () => {
-		setForceUpdate( dependencies );
-
+		setForceUpdate( [ window.innerWidth, window.innerHeight ] );
+		console.log( 'kjshgdkjhsdg' );
 		function updateSizeAndRerender() {
 			setForceUpdate( [ window.innerWidth, window.innerHeight ] );
 		}

--- a/wp-modules/app/js/src/hooks/useForceRerender.ts
+++ b/wp-modules/app/js/src/hooks/useForceRerender.ts
@@ -18,5 +18,5 @@ export default function useForceRerender< T extends unknown >(
 		window.addEventListener( 'resize', updateSizeAndRerender );
 		return () =>
 			window.removeEventListener( 'resize', updateSizeAndRerender );
-	}, [ ...dependencies ] );
+	}, [ dependencies ] );
 }

--- a/wp-modules/app/js/src/hooks/useLazyRender.ts
+++ b/wp-modules/app/js/src/hooks/useLazyRender.ts
@@ -79,7 +79,7 @@ export default function useLazyRender< T extends Element >(
 		return () => {
 			observer.disconnect();
 		};
-	}, [ lazyContainerRef ] );
+	}, [ lazyContainerRef, observerOptions ] );
 
 	return {
 		lazyIsIntersecting:

--- a/wp-modules/editor/js/src/components/Toggles/ModalToggle.tsx
+++ b/wp-modules/editor/js/src/components/Toggles/ModalToggle.tsx
@@ -20,6 +20,9 @@ export default function ModalToggle( {
 		if ( isDisabled && isChecked ) {
 			handleChangeMulti( false, 'blockTypes', blockTypeForModal );
 		}
+		// Disable eslint for exhaustive-deps as handleChangeMulti
+		// is a stable function and does not need to be included in the dependency array.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isDisabled, isChecked, blockTypeForModal ] );
 
 	return (

--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -154,13 +154,11 @@ export default function usePatternData( postMeta: PostMeta ) {
 		) {
 			updatePostMeta( 'postTypes', filteredPostTypes );
 		}
-		// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		postMeta.postTypes,
 		templatePartBlockTypeSelected,
 		filteredPostTypes,
-		,
+		updatePostMeta,
 	] );
 
 	function updatePostMeta(

--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -140,6 +140,8 @@ export default function usePatternData( postMeta: PostMeta ) {
 			templatePartBlockTypeSelected &&
 			! postMeta?.postTypes?.includes( 'wp_template' )
 		) {
+			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function. 
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', [
 				...postMeta.postTypes,
 				'wp_template',
@@ -152,12 +154,14 @@ export default function usePatternData( postMeta: PostMeta ) {
 			filteredPostTypes &&
 			! flatUnorderedEquals( postMeta.postTypes, filteredPostTypes )
 		) {
+			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function. 
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', filteredPostTypes );
 		}
 	}, [
 		postMeta.postTypes,
 		templatePartBlockTypeSelected,
-		filteredPostTypes,
+		filteredPostTypes,,
 	] );
 
 	function updatePostMeta(

--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -154,11 +154,13 @@ export default function usePatternData( postMeta: PostMeta ) {
 		) {
 			updatePostMeta( 'postTypes', filteredPostTypes );
 		}
+		// We can ignore this because updatePostMeta is always created fresh on every render.
+		// NOTE: make sure that other dependencies required are added in the future, as the linter could miss them here.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		postMeta.postTypes,
 		templatePartBlockTypeSelected,
 		filteredPostTypes,
-		updatePostMeta,
 	] );
 
 	function updatePostMeta(

--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -140,7 +140,7 @@ export default function usePatternData( postMeta: PostMeta ) {
 			templatePartBlockTypeSelected &&
 			! postMeta?.postTypes?.includes( 'wp_template' )
 		) {
-			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function. 
+			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', [
 				...postMeta.postTypes,
@@ -154,14 +154,15 @@ export default function usePatternData( postMeta: PostMeta ) {
 			filteredPostTypes &&
 			! flatUnorderedEquals( postMeta.postTypes, filteredPostTypes )
 		) {
-			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function. 
+			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', filteredPostTypes );
 		}
 	}, [
 		postMeta.postTypes,
 		templatePartBlockTypeSelected,
-		filteredPostTypes,,
+		filteredPostTypes,
+		,
 	] );
 
 	function updatePostMeta(

--- a/wp-modules/editor/js/src/hooks/usePatternData.ts
+++ b/wp-modules/editor/js/src/hooks/usePatternData.ts
@@ -140,8 +140,6 @@ export default function usePatternData( postMeta: PostMeta ) {
 			templatePartBlockTypeSelected &&
 			! postMeta?.postTypes?.includes( 'wp_template' )
 		) {
-			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', [
 				...postMeta.postTypes,
 				'wp_template',
@@ -154,10 +152,10 @@ export default function usePatternData( postMeta: PostMeta ) {
 			filteredPostTypes &&
 			! flatUnorderedEquals( postMeta.postTypes, filteredPostTypes )
 		) {
-			// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
 			updatePostMeta( 'postTypes', filteredPostTypes );
 		}
+		// Disabiling this eslint rule because updatePostMeta is not a dependency whose value we rely on, it is a function.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		postMeta.postTypes,
 		templatePartBlockTypeSelected,

--- a/wp-modules/editor/js/src/hooks/useSave.ts
+++ b/wp-modules/editor/js/src/hooks/useSave.ts
@@ -15,7 +15,10 @@ export default function useSave(
 		if ( isSavingPost ) {
 			updatePatternNames();
 		}
-	}, [ isSavingPost, updatePatternNames ] );
+		// We can ignore this because updatePatternNames is always created fresh on every render.
+		// NOTE: make sure that other dependencies required are added in the future, as the linter could miss them here.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isSavingPost ] );
 
 	async function updatePatternNames() {
 		const response = await fetch(

--- a/wp-modules/editor/js/src/hooks/useSave.ts
+++ b/wp-modules/editor/js/src/hooks/useSave.ts
@@ -15,7 +15,7 @@ export default function useSave(
 		if ( isSavingPost ) {
 			updatePatternNames();
 		}
-	}, [ isSavingPost ] );
+	}, [ isSavingPost, updatePatternNames ] );
 
 	async function updatePatternNames() {
 		const response = await fetch(

--- a/wp-modules/editor/js/src/utils/flatUnorderedEquals.ts
+++ b/wp-modules/editor/js/src/utils/flatUnorderedEquals.ts
@@ -1,6 +1,6 @@
 /** Check if two flat arrays are loosely equal. */
 export default function flatUnorderedEquals<
-	T extends string | number | boolean
+	T extends string | number | boolean,
 >( arrayA: T[], arrayB: T[] ) {
 	arrayA.sort();
 	arrayB.sort();

--- a/wp-modules/editor/js/src/utils/getCustomCategories.ts
+++ b/wp-modules/editor/js/src/utils/getCustomCategories.ts
@@ -7,7 +7,7 @@ import type { PostMeta } from '../types';
  * Human readable labels are used for the return array.
  */
 export default function getCustomCategories<
-	T extends { label: string; value: string; pm_custom?: boolean }
+	T extends { label: string; value: string; pm_custom?: boolean },
 >( selections: PostMeta[ 'categories' ], categoryOptions: T[] ) {
 	return categoryOptions.reduce(
 		( acc: PostMeta[ 'customCategories' ], category ) => {

--- a/wp-modules/editor/js/src/utils/getSelectedOptions.ts
+++ b/wp-modules/editor/js/src/utils/getSelectedOptions.ts
@@ -4,7 +4,7 @@ export default function getSelectedOptions<
 		label: string;
 		name?: string;
 		value?: string;
-	}
+	},
 >( selections: string[], availableOptions: T[], optionKey: keyof T ) {
 	return selections
 		.reduce(


### PR DESCRIPTION
## Tasks

- [x] I have signed the [Contributor License Agreement](https://wpeng.in/cla/) with WP Engine and understand that this plugin is not accepting community PRs for new features or major bug fixes with risk of regression. The PR I'm submitting is a minor bug fix.

### Summary of changes
This PR updates to the latest version of Pluginade Scripts, which is 0.0.3. See changelog in https://github.com/pluginade/pluginade-scripts/blob/main/CHANGELOG.md

One big update here is wp-scripts, and using the wp version of prettier.

### How to test
1. A functional change was made to useForceRender, so check that you can filter which patterns are shown and that they re-render
2. Test general usage of the app.
